### PR TITLE
Fix Hit Detection and Presentation Discrepancy

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -243,15 +243,24 @@ namespace SlotGame.Core
             TransitionTo(GamePhase.Evaluating);
 
             // 通常スピンの配当を加算
-            if (result.TotalWinAmount > 0)
+            if (result.TotalWinAmount > 0 || result.HasBonusCondition || result.HasScatter)
             {
-                _gameState.AddCoins(result.TotalWinAmount);
-                _gameState.RecordSpin(result.TotalWinAmount);
-                uiManager.UpdateCoins(_gameState.Coins);
+                if (result.TotalWinAmount > 0)
+                {
+                    _gameState.AddCoins(result.TotalWinAmount);
+                    _gameState.RecordSpin(result.TotalWinAmount);
+                    uiManager.UpdateCoins(_gameState.Coins);
+                }
+                else
+                {
+                    _gameState.RecordSpin(0);
+                }
 
                 TransitionTo(GamePhase.WinPresentation);
-                await uiManager.ShowWinAmount(result.TotalWinAmount, CalcWinLevel(result.TotalWinAmount));
-                uiManager.HighlightWinLines(result.LineWins);
+                if (result.TotalWinAmount > 0)
+                    await uiManager.ShowWinAmount(result.TotalWinAmount, CalcWinLevel(result.TotalWinAmount));
+
+                uiManager.HighlightWinLines(result);
                 await UniTask.Delay(TimeSpan.FromSeconds(1.5f), cancellationToken: ct);
                 uiManager.ClearLineHighlights();
             }

--- a/Assets/Scripts/Model/SpinResult.cs
+++ b/Assets/Scripts/Model/SpinResult.cs
@@ -2,13 +2,18 @@ using System.Collections.Generic;
 
 namespace SlotGame.Model
 {
+    /// <summary>シンボルの位置情報（[reel, row]）</summary>
+    public sealed record SymbolPosition(int Reel, int Row);
+
     /// <summary>1 スピンの結果（イミュータブルな値オブジェクト）</summary>
     public sealed record SpinResult(
         int[,]                 StoppedSymbolIds,   // [reel, row] ※配列は参照型なので変更注意
         IReadOnlyList<LineWin> LineWins,
         bool                   HasScatter,
         int                    ScatterCount,
+        IReadOnlyList<SymbolPosition> ScatterPositions,
         bool                   HasBonusCondition,
+        IReadOnlyList<SymbolPosition> BonusPositions,
         long                   TotalWinAmount
     );
 

--- a/Assets/Scripts/Utility/PaylineEvaluator.cs
+++ b/Assets/Scripts/Utility/PaylineEvaluator.cs
@@ -32,10 +32,13 @@ namespace SlotGame.Utility
         {
             var lineWins = EvaluatePaylines(symbolGrid, symbolDefs, paylines, betAmount);
 
-            int scatterCount    = CountScatters(symbolGrid, symbolDefs);
-            bool hasScatter     = scatterCount >= 3;
-            long scatterWin     = CalcScatterWin(scatterCount, payouts, betAmount);
-            bool hasBonusCondition = CheckBonusCondition(symbolGrid, symbolDefs);
+            var scatterPositions = GetScatterPositions(symbolGrid, symbolDefs);
+            int scatterCount     = scatterPositions.Count;
+            bool hasScatter      = scatterCount >= 3;
+            long scatterWin      = CalcScatterWin(scatterCount, payouts, betAmount);
+
+            var bonusPositions    = GetBonusPositions(symbolGrid, symbolDefs);
+            bool hasBonusCondition = CheckBonusConditionFromPositions(bonusPositions);
 
             long totalWin = scatterWin;
             foreach (var w in lineWins) totalWin += w.WinAmount;
@@ -45,7 +48,9 @@ namespace SlotGame.Utility
                 LineWins:          lineWins,
                 HasScatter:        hasScatter,
                 ScatterCount:      scatterCount,
+                ScatterPositions:  scatterPositions,
                 HasBonusCondition: hasBonusCondition,
+                BonusPositions:    bonusPositions,
                 TotalWinAmount:    totalWin
             );
         }
@@ -107,22 +112,23 @@ namespace SlotGame.Utility
             if (baseSym == null || baseSym.payouts == null || matchCount - MinMatch >= baseSym.payouts.Length)
                 return null;
 
-            long winAmount = (long)System.Math.Floor(baseSym.payouts[matchCount - MinMatch] * (bet / 25.0f));
+            long winAmount = (long)baseSym.payouts[matchCount - MinMatch] * bet;
             return new LineWin(lineIndex, baseSymbolId, matchCount, winAmount);
         }
 
         // ─── Scatter 判定 ─────────────────────────────────────────────────
 
-        private static int CountScatters(int[,] grid, SymbolData[] defs)
+        private static IReadOnlyList<SymbolPosition> GetScatterPositions(int[,] grid, SymbolData[] defs)
         {
-            int count = 0;
+            var positions = new List<SymbolPosition>();
             for (int r = 0; r < ReelCount; r++)
                 for (int row = 0; row < RowCount; row++)
                 {
                     var sym = FindSymbol(defs, grid[r, row]);
-                    if (sym?.type == SymbolType.Scatter) count++;
+                    if (sym?.type == SymbolType.Scatter)
+                        positions.Add(new SymbolPosition(r, row));
                 }
-            return count;
+            return positions;
         }
 
         private static long CalcScatterWin(int count, PayoutTableData payouts, int bet)
@@ -135,20 +141,30 @@ namespace SlotGame.Utility
 
         // ─── ボーナス条件判定 ─────────────────────────────────────────────
 
-        /// <summary>リール 0/2/4（0-indexed）それぞれに Bonus タイプのシンボルが 1 つ以上あれば true。</summary>
-        private static bool CheckBonusCondition(int[,] grid, SymbolData[] defs)
+        private static IReadOnlyList<SymbolPosition> GetBonusPositions(int[,] grid, SymbolData[] defs)
         {
-            foreach (int reel in new[] { 0, 2, 4 })
-            {
-                bool found = false;
+            var positions = new List<SymbolPosition>();
+            for (int r = 0; r < ReelCount; r++)
                 for (int row = 0; row < RowCount; row++)
                 {
-                    var sym = FindSymbol(defs, grid[reel, row]);
-                    if (sym?.type == SymbolType.Bonus) { found = true; break; }
+                    var sym = FindSymbol(defs, grid[r, row]);
+                    if (sym?.type == SymbolType.Bonus)
+                        positions.Add(new SymbolPosition(r, row));
                 }
-                if (!found) return false;
+            return positions;
+        }
+
+        /// <summary>リール 0/2/4（0-indexed）それぞれに Bonus タイプのシンボルが 1 つ以上あれば true。</summary>
+        private static bool CheckBonusConditionFromPositions(IReadOnlyList<SymbolPosition> positions)
+        {
+            bool has0 = false, has2 = false, has4 = false;
+            foreach (var pos in positions)
+            {
+                if (pos.Reel == 0) has0 = true;
+                else if (pos.Reel == 2) has2 = true;
+                else if (pos.Reel == 4) has4 = true;
             }
-            return true;
+            return has0 && has2 && has4;
         }
 
         // ─── ヘルパー ─────────────────────────────────────────────────────

--- a/Assets/Scripts/View/ReelView.cs
+++ b/Assets/Scripts/View/ReelView.cs
@@ -68,6 +68,11 @@ namespace SlotGame.View
                 AdvanceStrip();
             }
 
+            UpdateSymbolPositions();
+        }
+
+        private void UpdateSymbolPositions()
+        {
             // 全シンボルを offset 分だけ下にシフト
             for (int i = 0; i < BufferSize; i++)
             {
@@ -85,23 +90,28 @@ namespace SlotGame.View
             // 停止位置にスナップ
             AlignToStopIndex(targetStopIndex);
 
-            // バウンスアニメーション（中段シンボルを基準に DOTween）
-            var midView = _symbolViews[1];   // [0]=上バッファ, [1]=上段, [2]=中段（表示）
-            var rt      = midView.GetComponent<RectTransform>();
-            float targetY = rt.anchoredPosition.y;
-
-            // 少し行き過ぎてからバウンスで戻る
+            // バウンスアニメーション（リール全体）
+            float bounceAmount = 30f;
             await DOTween.To(
-                        () => rt.anchoredPosition,
-                        value => rt.anchoredPosition = value,
-                        new Vector2(rt.anchoredPosition.x, targetY - 20f),
+                        () => _scrollOffset,
+                        value =>
+                        {
+                            _scrollOffset = value;
+                            UpdateSymbolPositions();
+                        },
+                        -bounceAmount,
                         0.1f)
                     .SetEase(Ease.OutQuad)
                     .ToUniTask(cancellationToken: ct);
+
             await DOTween.To(
-                        () => rt.anchoredPosition,
-                        value => rt.anchoredPosition = value,
-                        new Vector2(rt.anchoredPosition.x, targetY),
+                        () => _scrollOffset,
+                        value =>
+                        {
+                            _scrollOffset = value;
+                            UpdateSymbolPositions();
+                        },
+                        0f,
                         0.15f)
                     .SetEase(Ease.OutBounce)
                     .ToUniTask(cancellationToken: ct);
@@ -131,10 +141,11 @@ namespace SlotGame.View
         }
 
         /// <summary>指定行のシンボルで当選アニメーションを再生して完了を待機する。</summary>
-        public async UniTask PlayWinAnimation(int row, AnimationClip clip, CancellationToken ct)
+        public async UniTask PlayWinAnimation(int row, CancellationToken ct)
         {
             // row: 0=上段, 1=中段, 2=下段 → _symbolViews インデックスは 1〜3
-            await _symbolViews[row + 1].PlayWinAnim(clip, ct);
+            if (_symbolViews == null || row + 1 >= _symbolViews.Length) return;
+            await _symbolViews[row + 1].PlayWinAnim(ct);
         }
 
         /// <summary>指定行のシンボルの世界座標を取得する（0=上, 1=中, 2=下）。</summary>
@@ -208,6 +219,9 @@ namespace SlotGame.View
             _symbolViews[2].SetSymbol(_strip.strip[mid]);
             _symbolViews[3].SetSymbol(_strip.strip[bot]);
             _symbolViews[4].SetSymbol(_strip.strip[botBuf]);
+
+            // ストリップ位置を更新して次のスピン開始時のジャンプを防ぐ
+            _stripIndex = topBuf;
         }
 
         private void SnapAllToGrid()

--- a/Assets/Scripts/View/SymbolView.cs
+++ b/Assets/Scripts/View/SymbolView.cs
@@ -10,9 +10,10 @@ namespace SlotGame.View
     [RequireComponent(typeof(Image))]
     public class SymbolView : MonoBehaviour
     {
-        private Image     _image;
-        private Animator  _animator;
-        private int       _symbolId;
+        private Image         _image;
+        private Animator      _animator;
+        private int           _symbolId;
+        private AnimationClip _winAnim;
 
         private void Awake()
         {
@@ -27,6 +28,7 @@ namespace SlotGame.View
             _symbolId    = data.symbolId;
             _image.sprite = data.sprite;
             _image.enabled = true;
+            _winAnim     = data.winAnim;
         }
 
         public void SetSymbolId(int id) => _symbolId = id;
@@ -52,10 +54,17 @@ namespace SlotGame.View
         }
 
         /// <summary>当選アニメーションを再生して完了を待機する。</summary>
+        public async UniTask PlayWinAnim(CancellationToken ct)
+        {
+            if (_animator == null || _winAnim == null) return;
+            _animator.Play(_winAnim.name);
+            await UniTask.Delay((int)(_winAnim.length * 1000), cancellationToken: ct);
+        }
+
+        /// <summary>当選アニメーションを再生して完了を待機する（引数指定版）。</summary>
         public async UniTask PlayWinAnim(AnimationClip clip, CancellationToken ct)
         {
             if (_animator == null || clip == null) return;
-            _animator.runtimeAnimatorController = null;
             _animator.Play(clip.name);
             await UniTask.Delay((int)(clip.length * 1000), cancellationToken: ct);
         }

--- a/Assets/Scripts/View/UIManager.cs
+++ b/Assets/Scripts/View/UIManager.cs
@@ -57,57 +57,77 @@ namespace SlotGame.View
         public async UniTask ShowWinAmount(long amount, WinLevel level)
             => await winPopup.Show(amount, level, this.GetCancellationTokenOnDestroy());
 
-        public void HighlightWinLines(IReadOnlyList<LineWin> wins)
+        public void HighlightWinLines(SpinResult result)
         {
             CacheReelViews();
             if (_reelViews == null || _reelViews.Length == 0) return;
 
             var highlightedRowsByReel = new Dictionary<int, HashSet<int>>();
+            var ct = this.GetCancellationTokenOnDestroy();
 
-            // --- 安全策: データが未設定なら処理を中断する ---
-            if (paylineData == null || paylinePrefab == null)
-            {
-                Debug.LogWarning("UIManager: PaylineData or PaylinePrefab is not assigned! Lines will not be drawn.");
-                // 配当計算などは終わっているので、ライン描画だけスキップする
-                return;
-            }
-
-            // --- ライン描画の追加 ---
+            // --- ペイライン描画 ---
             ClearPaylines();
 
-            foreach (var win in wins)
+            if (paylineData != null && paylinePrefab != null)
             {
-                if (win.LineIndex < 0 || win.LineIndex >= paylineData.lines.Length) continue;
-
-                var lineDef = paylineData.lines[win.LineIndex];
-                var points = new Vector3[win.MatchCount];
-                for (int i = 0; i < win.MatchCount; i++)
+                foreach (var win in result.LineWins)
                 {
-                    int row = lineDef.rows[i];
-                    points[i] = _reelViews[i].GetSymbolWorldPosition(row);
-                }
+                    if (win.LineIndex < 0 || win.LineIndex >= paylineData.lines.Length) continue;
 
-                var lineView = Instantiate(paylinePrefab, paylineParent != null ? paylineParent : transform);
-                lineView.DrawLine(points, GetLineColor(win.LineIndex));
-                _activePaylines.Add(lineView);
-
-                // --- シンボルのハイライト（薄暗くする演出用） ---
-                for (int i = 0; i < win.MatchCount; i++)
-                {
-                    if (!highlightedRowsByReel.TryGetValue(i, out var rows))
+                    var lineDef = paylineData.lines[win.LineIndex];
+                    var points = new Vector3[win.MatchCount];
+                    for (int i = 0; i < win.MatchCount; i++)
                     {
-                        rows = new HashSet<int>();
-                        highlightedRowsByReel.Add(i, rows);
+                        int row = lineDef.rows[i];
+                        points[i] = _reelViews[i].GetSymbolWorldPosition(row);
                     }
-                    rows.Add(lineDef.rows[i]);
+
+                    var lineView = Instantiate(paylinePrefab, paylineParent != null ? paylineParent : transform);
+                    lineView.DrawLine(points, GetLineColor(win.LineIndex));
+                    _activePaylines.Add(lineView);
+
+                    // シンボルハイライト追加
+                    for (int i = 0; i < win.MatchCount; i++)
+                    {
+                        AddHighlight(highlightedRowsByReel, i, lineDef.rows[i]);
+                    }
                 }
             }
 
+            // --- Scatter / Bonus ハイライト追加 ---
+            foreach (var pos in result.ScatterPositions)
+            {
+                AddHighlight(highlightedRowsByReel, pos.Reel, pos.Row);
+            }
+            foreach (var pos in result.BonusPositions)
+            {
+                AddHighlight(highlightedRowsByReel, pos.Reel, pos.Row);
+            }
+
+            // --- 表示反映 & アニメーション開始 ---
             for (int reelIndex = 0; reelIndex < _reelViews.Length; reelIndex++)
             {
                 highlightedRowsByReel.TryGetValue(reelIndex, out var rows);
                 _reelViews[reelIndex].HighlightRows(rows);
+
+                if (rows != null)
+                {
+                    foreach (int row in rows)
+                    {
+                        _reelViews[reelIndex].PlayWinAnimation(row, ct).Forget();
+                    }
+                }
             }
+        }
+
+        private void AddHighlight(Dictionary<int, HashSet<int>> dict, int reel, int row)
+        {
+            if (!dict.TryGetValue(reel, out var rows))
+            {
+                rows = new HashSet<int>();
+                dict.Add(reel, rows);
+            }
+            rows.Add(row);
         }
 
         private void ClearPaylines()


### PR DESCRIPTION
I have fixed the discrepancy between hit detection and visual presentation. The changes include correcting the payout calculation logic to match requirements, ensuring all winning symbols (including Scatters and Bonus triggers) are highlighted and animated, and fixing a visual jump bug in the reel stopping logic. I also improved the reel bounce animation and enabled individual winning animations for hit symbols.

---
*PR created automatically by Jules for task [6814967727383944858](https://jules.google.com/task/6814967727383944858) started by @handism*