### PR TITLE
fix: 設定・配当表画面表示中に背景を操作できないようモーダルブロッカーを追加

### DIFF
--- a/Assets/Scripts/View/UIManager.cs
+++ b/Assets/Scripts/View/UIManager.cs
@@ -45,6 +45,7 @@ namespace SlotGame.View
         private TMP_Text? _modeTitleText;
         private TMP_Text? _modeSubtitleText;
         private Camera? _mainCamera;
+        private CanvasGroup? _modalBlocker;
 
         private static readonly Color NormalTint     = new(0.05f, 0.08f, 0.14f, 0f);
         private static readonly Color FreeSpinTint   = new(0.08f, 0.36f, 0.52f, 0.3f);
@@ -314,10 +315,33 @@ namespace SlotGame.View
             }
         }
 
-        public void ShowSettings()  => settingsView.ShowAsync(this.GetCancellationTokenOnDestroy()).Forget();
-        public void HideSettings()  => settingsView.HideAsync(this.GetCancellationTokenOnDestroy()).Forget();
-        public void ShowPaytable()  => paytableView.ShowAsync(this.GetCancellationTokenOnDestroy()).Forget();
-        public void HidePaytable()  => paytableView.HideAsync(this.GetCancellationTokenOnDestroy()).Forget();
+        public void ShowSettings()
+        {
+            ShowModalBlocker(settingsView != null ? settingsView.transform : null);
+            settingsView.ShowAsync(this.GetCancellationTokenOnDestroy()).Forget();
+        }
+
+        public void HideSettings() => HideSettingsAsync(this.GetCancellationTokenOnDestroy()).Forget();
+
+        public void ShowPaytable()
+        {
+            ShowModalBlocker(paytableView != null ? paytableView.transform : null);
+            paytableView.ShowAsync(this.GetCancellationTokenOnDestroy()).Forget();
+        }
+
+        public void HidePaytable() => HidePaytableAsync(this.GetCancellationTokenOnDestroy()).Forget();
+
+        private async UniTaskVoid HideSettingsAsync(CancellationToken ct)
+        {
+            try   { await settingsView.HideAsync(ct); }
+            finally { HideModalBlocker(); }
+        }
+
+        private async UniTaskVoid HidePaytableAsync(CancellationToken ct)
+        {
+            try   { await paytableView.HideAsync(ct); }
+            finally { HideModalBlocker(); }
+        }
 
         public void SetSettingsVolumes(float bgm, float se)
         {
@@ -340,6 +364,68 @@ namespace SlotGame.View
             _reelViews = views
                 .OrderBy(v => v.transform.position.x)
                 .ToArray();
+        }
+
+        private void EnsureModalBlocker()
+        {
+            if (_modalBlocker != null) return;
+
+            _rootCanvas ??= mainHUD != null ? mainHUD.GetComponentInParent<Canvas>() : FindFirstObjectByType<Canvas>();
+            if (_rootCanvas == null) return;
+
+            var go = new GameObject("ModalBlocker", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(CanvasGroup));
+            go.transform.SetParent(_rootCanvas.transform, false);
+
+            var rect = go.GetComponent<RectTransform>();
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+
+            var img = go.GetComponent<Image>();
+            img.color = new Color(0f, 0f, 0f, 0.45f);
+            img.raycastTarget = true;
+
+            _modalBlocker = go.GetComponent<CanvasGroup>();
+            _modalBlocker.alpha = 0f;
+            _modalBlocker.blocksRaycasts = false;
+            go.SetActive(false);
+        }
+
+        private void ShowModalBlocker(Transform? modalTransform)
+        {
+            EnsureModalBlocker();
+            if (_modalBlocker == null) return;
+
+            if (modalTransform != null)
+            {
+                // ブロッカーをモーダルパネルの直前（背後）に配置する
+                var directChild = GetDirectChildOfCanvas(modalTransform);
+                if (directChild != null)
+                    _modalBlocker.transform.SetSiblingIndex(directChild.GetSiblingIndex());
+            }
+
+            _modalBlocker.gameObject.SetActive(true);
+            _modalBlocker.blocksRaycasts = true;
+            _modalBlocker.alpha = 1f;
+        }
+
+        private void HideModalBlocker()
+        {
+            if (_modalBlocker == null) return;
+            _modalBlocker.blocksRaycasts = false;
+            _modalBlocker.alpha = 0f;
+            _modalBlocker.gameObject.SetActive(false);
+        }
+
+        /// <summary>transform の祖先のうち、ルートキャンバスの直接の子を返す。</summary>
+        private Transform? GetDirectChildOfCanvas(Transform target)
+        {
+            if (_rootCanvas == null) return target;
+            var current = target;
+            while (current != null && current.parent != null && current.parent != _rootCanvas.transform)
+                current = current.parent;
+            return current;
         }
 
         private void EnsureModeVisuals()


### PR DESCRIPTION
UIManager に全画面の ModalBlocker オーバーレイ（CanvasGroup + raycastTarget=true）を
動的生成し、ShowSettings/ShowPaytable 呼び出し時に blocksRaycasts=true で有効化する。
HideSettings/HidePaytable はパネルの閉じアニメーション完了後に blocker を無効化する。

https://claude.ai/code/session_01GDYGeLd548BVwVnG2DofYE