### PR TITLE
fix: リールストリップ長の仕様乖離を修正 (#22)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -72,7 +72,7 @@ View（MonoBehaviour・表示専用）
 | アセット | 内容 |
 |---------|------|
 | `SymbolData` × 11 | 各シンボルの配当倍率・スプライト・アニメ（Bonus シンボル含む） |
-| `ReelStripData` × 5 | リールの出目テーブル（重み付き確率、1リール 60 スロット） |
+| `ReelStripData` × 5 | リールの出目テーブル（重み付き確率、1リール 88 スロット） |
 | `PaylineData` | 25 ペイラインの定義（行インデックス配列） |
 | `PayoutTableData` | Scatter 配当・ボーナス報酬の重み |
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -140,8 +140,8 @@ Assets/
   - 配当倍率を `docs/requirements.md` の値に従って設定
   - `SymbolType.Bonus` シンボル（ID=10、宝箱用）を追加済み
   - **生成方法**: Unity Editor で `SlotGame/Create All ScriptableObject Assets` を実行
-- [x] `ReelStripData` アセット × 5（仮データ、各リール 60 シンボル・フェーズ 5 で最終調整）
-  - Dragon×2, Phoenix×3, Crystal×4, Sword×5, Ace×10, King×10, Queen×10, Jack×10, Wild×3, Scatter×2, Bonus×1
+- [x] `ReelStripData` アセット × 5（各リール 88 スロット）
+  - Dragon×2, Phoenix×3, Crystal×4, Sword×5, Ace×10, King×10, Queen×10, Jack×9, Wild×3, Scatter×3, Bonus×3, Blank×26
   - 素数ステップ（7）インターリーブで均等分散、リールごとにオフセット
 - [x] `PaylineData` アセット（25 ライン定義を `requirements.md` から転記済み）
 - [x] `PayoutTableData` アセット

--- a/docs/design.md
+++ b/docs/design.md
@@ -460,7 +460,7 @@ public class SeededRandomGenerator : IRandomGenerator { ... }
   - `SymbolData.payouts` は `int[]`（倍率を整数で保持）
   - 最終配当は `betAmount * payouts[matchCount - 3]`（整数演算のみ）で算出する
 - `ReelStripData` のストリップは重み付き確率テーブルとして機能
-  - 例: Dragon はストリップ 60 マス中 2 マス（出現率 3.3%）
+  - 例: Dragon はストリップ 88 マス中 2 マス（出現率 2.3%）
 - フリースピン中の乱数は通常と同じ系列（有利化なし、倍率のみ変化）
 - ボーナスラウンドの宝箱報酬は `PayoutTableData` の重みに従い抽選
 


### PR DESCRIPTION
## Summary

- `docs/design.md`: Dragon の確率例を「60マス中 2マス（3.3%）」→「88マス中 2マス（2.3%）」に修正
- `.claude/CLAUDE.md`: ScriptableObject テーブルの「1リール 60 スロット」→「1リール 88 スロット」に修正
- `PLAN.md`: ReelStripData の説明を実際のシンボル構成（88スロット、Blank×26）に更新

**修正方針**: 実装（88スロット）はRTP 96%検証済みのため、ドキュメント側を合わせる。

> **注意**: 現在のアセット（.asset）は 93 エントリで 88 と不一致。Unity Editor の `SlotGame/Create All ScriptableObject Assets` を実行してアセットを再生成してください。

## Test plan

- [ ] ドキュメント修正のみのため、コード変更なし
- [ ] Unity Editor でアセット再生成後、strip 配列エントリ数が 88 であることを確認
- [ ] `RtpCalculator` Edit Mode テストで RTP 96% が維持されることを確認

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)