### PR TITLE
docs: シンボル数の記載を全ドキュメントで 12 に統一 (closes #27)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -71,7 +71,7 @@ View（MonoBehaviour・表示専用）
 
 | アセット | 内容 |
 |---------|------|
-| `SymbolData` × 11 | 各シンボルの配当倍率・スプライト・アニメ（Bonus シンボル含む） |
+| `SymbolData` × 12 | 各シンボルの配当倍率・スプライト・アニメ（Bonus・Blank シンボル含む） |
 | `ReelStripData` × 5 | リールの出目テーブル（重み付き確率、1リール 88 スロット） |
 | `PaylineData` | 25 ペイラインの定義（行インデックス配列） |
 | `PayoutTableData` | Scatter 配当・ボーナス報酬の重み |

--- a/docs/design.md
+++ b/docs/design.md
@@ -531,7 +531,7 @@ Assets/
     Utility/            ← PaylineEvaluator（static）, SaveDataManager
 
   ScriptableObjects/
-    Symbols/            ← SymbolData × 10
+    Symbols/            ← SymbolData × 12
     Reels/              ← ReelStripData × 5
     Paylines/           ← PaylineData（1ファイル）
     PayoutTable/        ← PayoutTableData（1ファイル）


### PR DESCRIPTION
## 変更内容

Issue #27 で報告されたドキュメント間のシンボル数不一致を修正。

| ファイル | 修正前 | 修正後 |
|---------|--------|--------|
| `docs/design.md` | `SymbolData × 10` | `SymbolData × 12` |
| `.claude/CLAUDE.md` | `SymbolData × 11`（Bonus のみ言及） | `SymbolData × 12`（Blank も明記） |

`docs/requirements.md` はすでに Bonus・Blank を含む 12 シンボルが正しく記載されているため変更なし。

closes #27