### PR TITLE
docs: PayoutTableData の設計書を実装に合わせて修正 (closes #28)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -152,9 +152,22 @@ public struct PaylineEntry
 [CreateAssetMenu]
 public class PayoutTableData : ScriptableObject
 {
-    public ScatterPayout[] scatterPayouts;  // Scatter個数→倍率
-    public BonusRewardRange bonusRange;     // ×5 〜 ×100
+    public ScatterPayout[]    scatterPayouts;    // Scatter個数→倍率
+    public FreeSpinReward[]   freeSpinRewards;   // Scatter個数→フリースピン回数
+    public int                freeSpinMultiplier; // フリースピン中の配当倍率
+    public BonusRewardEntry[] bonusRewards;      // ボーナスラウンド報酬の重み付きテーブル
 }
+
+// ボーナス報酬エントリ（重み付き抽選テーブル）
+// 宝箱選択時に weight に従って抽選し、multiplier × betAmount がプレイヤーに付与される
+[Serializable]
+public struct BonusRewardEntry
+{
+    public int multiplier;  // ベット額に掛ける倍率（例: ×5〜×100）
+    public int weight;      // 抽選重み（合計に対する比率で確率が決まる）
+}
+// 例: { multiplier=5, weight=40 }, { multiplier=10, weight=25 }, ..., { multiplier=100, weight=3 }
+// → ×5 が最も出やすく（40/100）、×100 は低確率（3/100）
 ```
 
 ---


### PR DESCRIPTION
## Summary

- `docs/design.md` セクション 4.1 の `PayoutTableData` を実装と一致させた
- `BonusRewardRange`（単一レンジ定義）→ `BonusRewardEntry[]`（重み付き抽選テーブル）に修正
- 実装に存在する `FreeSpinReward[]` / `freeSpinMultiplier` フィールドも追記
- `BonusRewardEntry` 構造体の定義と重み付き抽選の仕組み、具体的な倍率・重みの例をコメントで明示

## Test plan

- [ ] `docs/design.md` の `PayoutTableData` クラス定義が `Assets/Scripts/Data/PayoutTableData.cs` と一致していることを確認
- [ ] `BonusRewardEntry` の説明コメントが RTP 計算への影響（重み付き確率）を正しく伝えていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)