### PR TITLE
feat(ui): メッシュグラデーションとドットパターン背景を追加

### DIFF
--- a/Assets/Scripts/View/DotPatternBackground.cs
+++ b/Assets/Scripts/View/DotPatternBackground.cs
@@ -1,0 +1,117 @@
+#nullable enable
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace SlotGame.View
+{
+    /// <summary>
+    /// 手続き生成した Texture2D のタイリングで全画面ドットパターン背景を表示するコンポーネント。
+    /// RawImage を使い uvRect を Canvas サイズに合わせることで物理的なドットサイズを一定に保つ。
+    /// </summary>
+    [RequireComponent(typeof(RawImage))]
+    public class DotPatternBackground : MonoBehaviour
+    {
+        [SerializeField] private int   _tileSize  = 32;   // タイルテクスチャのピクセルサイズ
+        [SerializeField] private float _dotRadius = 3.5f; // ドットの半径（ピクセル）
+
+        private static readonly Color NormalDot     = new(0.4f, 0.6f, 1f,  0.10f);
+        private static readonly Color FreeSpinDot   = new(0.2f, 0.9f, 1f,  0.12f);
+        private static readonly Color BonusRoundDot = new(1f,   0.6f, 0.2f, 0.12f);
+
+        private RawImage   _rawImage   = null!;
+        private Texture2D? _dotTexture;
+
+        private void Awake()
+        {
+            _rawImage = GetComponent<RawImage>();
+            _rawImage.raycastTarget = false;
+
+            // fullscreen stretch
+            var rt = GetComponent<RectTransform>();
+            rt.anchorMin = Vector2.zero;
+            rt.anchorMax = Vector2.one;
+            rt.offsetMin = Vector2.zero;
+            rt.offsetMax = Vector2.zero;
+        }
+
+        private void Start()
+        {
+            GenerateDotTexture(NormalDot);
+        }
+
+        private void OnDestroy()
+        {
+            DestroyTexture();
+        }
+
+        protected void OnRectTransformDimensionsChange()
+        {
+            if (_rawImage != null && _dotTexture != null)
+                UpdateUVRect();
+        }
+
+        /// <summary>ゲームモードに応じてドットの色を切り替える。</summary>
+        public void SetMode(ModeVisualType mode)
+        {
+            Color dotColor = mode switch
+            {
+                ModeVisualType.FreeSpin   => FreeSpinDot,
+                ModeVisualType.BonusRound => BonusRoundDot,
+                _                         => NormalDot,
+            };
+            GenerateDotTexture(dotColor);
+        }
+
+        private void GenerateDotTexture(Color dotColor)
+        {
+            DestroyTexture();
+
+            int size = Mathf.Max(4, _tileSize);
+            _dotTexture = new Texture2D(size, size, TextureFormat.RGBA32, false)
+            {
+                wrapMode   = TextureWrapMode.Repeat,
+                filterMode = FilterMode.Bilinear,
+                name       = "DotPatternTile",
+            };
+
+            Color[] pixels = new Color[size * size];
+            Vector2 center = new(size * 0.5f, size * 0.5f);
+
+            for (int y = 0; y < size; y++)
+            {
+                for (int x = 0; x < size; x++)
+                {
+                    float dist = Vector2.Distance(new Vector2(x + 0.5f, y + 0.5f), center);
+                    // SDF 的アンチエイリアシング（境界を 1px でぼかす）
+                    float t = Mathf.Clamp01(_dotRadius - dist + 1f);
+                    pixels[y * size + x] = new Color(dotColor.r, dotColor.g, dotColor.b, dotColor.a * t);
+                }
+            }
+
+            _dotTexture.SetPixels(pixels);
+            _dotTexture.Apply();
+
+            _rawImage.texture = _dotTexture;
+            _rawImage.color   = Color.white;
+            UpdateUVRect();
+        }
+
+        private void UpdateUVRect()
+        {
+            if (_dotTexture == null) return;
+            var rect = GetComponent<RectTransform>().rect;
+            float tilesX = rect.width  / _tileSize;
+            float tilesY = rect.height / _tileSize;
+            _rawImage.uvRect = new Rect(0f, 0f, tilesX, tilesY);
+        }
+
+        private void DestroyTexture()
+        {
+            if (_dotTexture != null)
+            {
+                Destroy(_dotTexture);
+                _dotTexture = null;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/View/MainHUDView.cs
+++ b/Assets/Scripts/View/MainHUDView.cs
@@ -33,6 +33,28 @@ namespace SlotGame.View
             if (autoButtonText == null && autoSpinButton != null)
                 autoButtonText = autoSpinButton.GetComponentInChildren<TMP_Text>();
 
+            // スピンボタンにブルー系グラデーションを適用
+            var spinImg = spinButton != null ? spinButton.GetComponent<Image>() : null;
+            if (spinImg != null)
+            {
+                var grad = spinImg.gameObject.AddComponent<UIGradient>();
+                grad.SetColors(
+                    new Color(0.3f, 0.5f, 0.9f, 1f),
+                    new Color(0.05f, 0.15f, 0.4f, 1f)
+                );
+            }
+
+            // オートスピンボタンにも同系統のグラデーションを適用
+            var autoImg = autoSpinButton != null ? autoSpinButton.GetComponent<Image>() : null;
+            if (autoImg != null)
+            {
+                var grad = autoImg.gameObject.AddComponent<UIGradient>();
+                grad.SetColors(
+                    new Color(0.25f, 0.4f, 0.75f, 1f),
+                    new Color(0.04f, 0.12f, 0.32f, 1f)
+                );
+            }
+
             for (int i = 0; i < betButtons.Length; i++)
             {
                 int bet = betValues[i];
@@ -76,23 +98,38 @@ namespace SlotGame.View
                 var button = betButtons[i];
                 var image = button != null ? button.GetComponent<Image>() : null;
                 var label = button != null ? button.GetComponentInChildren<TMP_Text>() : null;
+
                 if (image != null)
                 {
-                    var baseColor = isSelected
-                        ? new Color(0.95f, 0.71f, 0.24f, 0.96f)
-                        : new Color(0.16f, 0.23f, 0.37f, 0.92f);
-                    image.color = baseColor;
+                    // グラデーションコンポーネントに色を委譲するため Image.color は白に統一
+                    image.color = Color.white;
+
+                    var grad = image.GetComponent<UIGradient>() ?? image.gameObject.AddComponent<UIGradient>();
+                    if (isSelected)
+                    {
+                        grad.SetColors(
+                            new Color(1f,   0.85f, 0.4f,  0.96f),
+                            new Color(0.7f, 0.45f, 0.1f,  0.96f)
+                        );
+                    }
+                    else
+                    {
+                        grad.SetColors(
+                            new Color(0.22f, 0.32f, 0.5f,  0.92f),
+                            new Color(0.1f,  0.15f, 0.28f, 0.92f)
+                        );
+                    }
 
                     var colors = button.colors;
-                    colors.normalColor = baseColor;
+                    colors.normalColor = Color.white;
                     colors.highlightedColor = isSelected
-                        ? new Color(1f, 0.78f, 0.34f, 1f)
-                        : new Color(0.22f, 0.3f, 0.46f, 1f);
+                        ? new Color(1f, 0.92f, 0.55f, 1f)
+                        : new Color(0.3f, 0.4f, 0.6f, 1f);
                     colors.pressedColor = isSelected
-                        ? new Color(0.82f, 0.58f, 0.16f, 1f)
-                        : new Color(0.1f, 0.16f, 0.28f, 1f);
-                    colors.selectedColor = colors.highlightedColor;
-                    colors.disabledColor = new Color(baseColor.r, baseColor.g, baseColor.b, 0.45f);
+                        ? new Color(0.85f, 0.6f, 0.2f, 1f)
+                        : new Color(0.08f, 0.12f, 0.22f, 1f);
+                    colors.selectedColor    = colors.highlightedColor;
+                    colors.disabledColor    = new Color(1f, 1f, 1f, 0.35f);
                     button.colors = colors;
                 }
 
@@ -100,7 +137,7 @@ namespace SlotGame.View
                 {
                     label.color = isSelected
                         ? new Color(0.11f, 0.09f, 0.06f, 1f)
-                        : new Color(0.92f, 0.96f, 1f, 0.96f);
+                        : new Color(0.92f, 0.96f, 1f,    0.96f);
                 }
             }
         }

--- a/Assets/Scripts/View/UIGradient.cs
+++ b/Assets/Scripts/View/UIGradient.cs
@@ -1,0 +1,136 @@
+#nullable enable
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace SlotGame.View
+{
+    /// <summary>
+    /// UGUI の Graphic メッシュ頂点カラーを書き換えてグラデーションを実現するコンポーネント。
+    /// BaseMeshEffect を継承しカスタムシェーダー不要でコードのみで動作する。
+    /// </summary>
+    [RequireComponent(typeof(Graphic))]
+    public class UIGradient : BaseMeshEffect
+    {
+        public enum GradientDirection
+        {
+            TopToBottom,
+            LeftToRight,
+            FourCorner,
+        }
+
+        [SerializeField] private GradientDirection _direction = GradientDirection.TopToBottom;
+        [SerializeField] private Color _topColor    = Color.white;
+        [SerializeField] private Color _bottomColor = new(0.6f, 0.6f, 0.6f, 1f);
+
+        // FourCorner 用（TopToBottom / LeftToRight の場合は _topColor / _bottomColor を使用）
+        [SerializeField] private Color _topLeftColor     = Color.white;
+        [SerializeField] private Color _topRightColor    = Color.white;
+        [SerializeField] private Color _bottomLeftColor  = new(0.6f, 0.6f, 0.6f, 1f);
+        [SerializeField] private Color _bottomRightColor = new(0.6f, 0.6f, 0.6f, 1f);
+
+        private readonly List<UIVertex> _tempVerts = new();
+
+        /// <summary>TopToBottom または LeftToRight グラデーションの色を設定してメッシュを更新する。</summary>
+        public void SetColors(Color top, Color bottom)
+        {
+            _topColor    = top;
+            _bottomColor = bottom;
+            if (graphic != null)
+                graphic.SetVerticesDirty();
+        }
+
+        /// <summary>FourCorner グラデーションの色を設定してメッシュを更新する。</summary>
+        public void SetColors(Color topLeft, Color topRight, Color bottomLeft, Color bottomRight)
+        {
+            _direction        = GradientDirection.FourCorner;
+            _topLeftColor     = topLeft;
+            _topRightColor    = topRight;
+            _bottomLeftColor  = bottomLeft;
+            _bottomRightColor = bottomRight;
+            if (graphic != null)
+                graphic.SetVerticesDirty();
+        }
+
+        /// <summary>グラデーション方向を変更してメッシュを更新する。</summary>
+        public void SetDirection(GradientDirection direction)
+        {
+            _direction = direction;
+            if (graphic != null)
+                graphic.SetVerticesDirty();
+        }
+
+        public override void ModifyMesh(VertexHelper vh)
+        {
+            if (!IsActive()) return;
+
+            _tempVerts.Clear();
+            vh.GetUIVertexStream(_tempVerts);
+
+            if (_tempVerts.Count == 0) return;
+
+            // 頂点の Y/X 範囲を求める
+            float yMin = float.MaxValue, yMax = float.MinValue;
+            float xMin = float.MaxValue, xMax = float.MinValue;
+
+            foreach (var v in _tempVerts)
+            {
+                if (v.position.y < yMin) yMin = v.position.y;
+                if (v.position.y > yMax) yMax = v.position.y;
+                if (v.position.x < xMin) xMin = v.position.x;
+                if (v.position.x > xMax) xMax = v.position.x;
+            }
+
+            float yRange = yMax - yMin;
+            float xRange = xMax - xMin;
+
+            for (int i = 0; i < _tempVerts.Count; i++)
+            {
+                var vertex = _tempVerts[i];
+                Color gradColor;
+
+                switch (_direction)
+                {
+                    case GradientDirection.LeftToRight:
+                    {
+                        float tx = xRange > 0f ? (vertex.position.x - xMin) / xRange : 0f;
+                        gradColor = Color.Lerp(_topColor, _bottomColor, tx);
+                        break;
+                    }
+                    case GradientDirection.FourCorner:
+                    {
+                        float tx = xRange > 0f ? (vertex.position.x - xMin) / xRange : 0f;
+                        float ty = yRange > 0f ? (vertex.position.y - yMin) / yRange : 0f;
+                        Color bottom = Color.Lerp(_bottomLeftColor, _bottomRightColor, tx);
+                        Color top    = Color.Lerp(_topLeftColor,    _topRightColor,    tx);
+                        gradColor = Color.Lerp(bottom, top, ty);
+                        break;
+                    }
+                    default: // TopToBottom
+                    {
+                        float ty = yRange > 0f ? (vertex.position.y - yMin) / yRange : 0f;
+                        gradColor = Color.Lerp(_bottomColor, _topColor, ty);
+                        break;
+                    }
+                }
+
+                // 既存の頂点カラー（Image.color 等）と乗算合成する
+                vertex.color = Multiply(vertex.color, (Color32)gradColor);
+                _tempVerts[i] = vertex;
+            }
+
+            vh.Clear();
+            vh.AddUIVertexTriangleStream(_tempVerts);
+        }
+
+        private static Color32 Multiply(Color32 a, Color32 b)
+        {
+            return new Color32(
+                (byte)(a.r * b.r / 255),
+                (byte)(a.g * b.g / 255),
+                (byte)(a.b * b.b / 255),
+                (byte)(a.a * b.a / 255)
+            );
+        }
+    }
+}

--- a/Assets/Scripts/View/UIManager.cs
+++ b/Assets/Scripts/View/UIManager.cs
@@ -48,6 +48,7 @@ namespace SlotGame.View
         private TMP_Text? _modeSubtitleText;
         private Camera? _mainCamera;
         private CanvasGroup? _hudCanvasGroup;
+        private DotPatternBackground? _dotPatternBg;
 
         private static readonly Color NormalTint     = new(0.05f, 0.08f, 0.14f, 0f);
         private static readonly Color FreeSpinTint   = new(0.08f, 0.36f, 0.52f, 0.3f);
@@ -339,6 +340,8 @@ namespace SlotGame.View
                     _                         => NormalCameraColor,
                 };
             }
+
+            _dotPatternBg?.SetMode(mode);
         }
 
         public async UniTask ShowModeTransitionAsync(
@@ -469,7 +472,7 @@ namespace SlotGame.View
 
         private void EnsureModeVisuals()
         {
-            if (_modeTintOverlay != null && _modeAnnouncementGroup != null)
+            if (_dotPatternBg != null && _modeTintOverlay != null && _modeAnnouncementGroup != null)
             {
                 return;
             }
@@ -480,11 +483,21 @@ namespace SlotGame.View
                 return;
             }
 
+            // ドットパターン背景を最背面（sibling 0）に生成
+            if (_dotPatternBg == null)
+            {
+                var dotObject = new GameObject("DotPatternBackground", typeof(RectTransform), typeof(CanvasRenderer), typeof(UnityEngine.UI.RawImage));
+                dotObject.transform.SetParent(_rootCanvas.transform, false);
+                _dotPatternBg = dotObject.AddComponent<DotPatternBackground>();
+                dotObject.transform.SetAsFirstSibling();
+            }
+
             if (_modeTintOverlay == null)
             {
                 var tintObject = new GameObject("ModeTintOverlay", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
                 tintObject.transform.SetParent(_rootCanvas.transform, false);
-                tintObject.transform.SetAsFirstSibling();
+                // DotPatternBackground（index 0）の直後 index 1 に配置
+                tintObject.transform.SetSiblingIndex(1);
 
                 var rect = tintObject.GetComponent<RectTransform>();
                 rect.anchorMin = Vector2.zero;

--- a/Assets/Scripts/View/WinPopupView.cs
+++ b/Assets/Scripts/View/WinPopupView.cs
@@ -23,7 +23,18 @@ namespace SlotGame.View
             _canvasGroup = GetComponent<CanvasGroup>();
             if (_canvasGroup == null) _canvasGroup = gameObject.AddComponent<CanvasGroup>();
             _canvasGroup.alpha = 0;
-            
+
+            // ポップアップ背景 Image にダークネイビーグラデーションを適用
+            var bgImage = GetComponent<UnityEngine.UI.Image>();
+            if (bgImage != null)
+            {
+                var grad = bgImage.gameObject.AddComponent<UIGradient>();
+                grad.SetColors(
+                    new Color(0.08f, 0.12f, 0.25f, 0.95f),
+                    new Color(0.03f, 0.05f, 0.15f, 0.98f)
+                );
+            }
+
             // テキストの初期スタイル設定
             ApplyInitialStyle(winAmountText);
             ApplyInitialStyle(winLevelText);


### PR DESCRIPTION
## Summary

- **UIGradient コンポーネント（新規）**: `BaseMeshEffect` を継承し、カスタムシェーダー不要でコードのみで UI メッシュへグラデーションを適用。`TopToBottom` / `LeftToRight` / `FourCorner` の 3 方向をサポート
- **DotPatternBackground コンポーネント（新規）**: `RawImage` + `Texture2D` 手続き生成でドットパターンをタイリング。ゲームモード別に色変化（Normal=ブルー / FreeSpin=シアン / BonusRound=アンバー）
- **UIManager**: `EnsureModeVisuals()` に `DotPatternBackground` 生成を追加（sibling index 0）。`ApplyModeVisual()` からモード変更を伝播
- **MainHUDView**: ベットボタン（選択=ゴールド→アンバー / 非選択=ライト→ダークネイビー）、スピン/オートスピンボタン（ブルー系）にグラデーションを適用
- **WinPopupView**: ポップアップ背景 Image にダークネイビーグラデーションを適用

## Test plan

- [ ] Play モード開始時に Console エラーなし（`NullReferenceException` がないこと）
- [ ] Hierarchy で `DotPatternBackground` が sibling index 0、`ModeTintOverlay` が index 1 に存在すること
- [ ] Normal / FreeSpin / BonusRound のモード遷移でドットパターンの色が変わること
- [ ] ベットボタンの選択/非選択で色が切り替わること
- [ ] スピンボタンにブルー系グラデーションが表示されること
- [ ] WinPopup 表示時にネイビーグラデーション背景が表示されること
- [ ] `DOPunchScale` / `DOScale` アニメーション中にグラデーションが崩れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)