### PR TITLE
feat: WinPopup表示中のみペイラインアニメーションを再生 (Issue #19)

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -404,11 +404,7 @@ namespace SlotGame.Core
                 {
                     uiManager.UpdateWin(result.TotalWinAmount);
                     PlayWinSe(result.TotalWinAmount);
-                    // ポップアップとハイライトを並行実行
-                    await UniTask.WhenAll(
-                        uiManager.ShowWinAmount(result.TotalWinAmount, CalcWinLevel(result.TotalWinAmount)),
-                        uiManager.HighlightWinLinesAsync(result, ct, paylineData)
-                    );
+                    await uiManager.ShowWinAndHighlightAsync(result.TotalWinAmount, CalcWinLevel(result.TotalWinAmount), result, ct, paylineData);
                 }
                 else
                 {
@@ -511,10 +507,7 @@ namespace SlotGame.Core
                     uiManager.ShowFreeSpinHUD(_gameState.FreeSpinsLeft, cumulativeFreeSpinWin);
                     if (result.TotalWinAmount > 0)
                     {
-                        await UniTask.WhenAll(
-                            uiManager.ShowWinAmount(win, CalcWinLevel(win)),
-                            uiManager.HighlightWinLinesAsync(result, ct, paylineData)
-                        );
+                        await uiManager.ShowWinAndHighlightAsync(win, CalcWinLevel(win), result, ct, paylineData);
                         await UniTask.Delay(TimeSpan.FromSeconds(0.5f), cancellationToken: ct);
                         uiManager.ClearLineHighlights();
                     }

--- a/Assets/Scripts/View/UIManager.cs
+++ b/Assets/Scripts/View/UIManager.cs
@@ -132,6 +132,35 @@ namespace SlotGame.View
         public async UniTask ShowWinAmount(long amount, WinLevel level)
             => await winPopup.Show(amount, level, this.GetCancellationTokenOnDestroy());
 
+        /// <summary>
+        /// WinPopup 表示とペイラインハイライトを連動させて実行する。
+        /// ポップアップが閉じると同時にアニメーションを停止する。
+        /// </summary>
+        public async UniTask ShowWinAndHighlightAsync(long amount, WinLevel level, SpinResult result, CancellationToken ct, PaylineData? overridePaylineData = null)
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct, this.GetCancellationTokenOnDestroy());
+
+            await UniTask.WhenAll(
+                winPopup.Show(amount, level, cts.Token),
+                HighlightWinLinesAsync(result, cts.Token, overridePaylineData)
+            );
+
+            // ポップアップ終了後にアニメーションを停止
+            StopWinAnimations();
+        }
+
+        private void StopWinAnimations()
+        {
+            if (_reelViews == null) return;
+            foreach (var reel in _reelViews)
+            {
+                for (int row = 0; row < 3; row++)
+                {
+                    reel.GetSymbolView(row)?.StopPulseAnimation();
+                }
+            }
+        }
+
         public void SetupReels(IEnumerable<ReelView> reels)
         {
             _reelViews = reels.ToArray();


### PR DESCRIPTION
## 概要

Issue #19「勝利ペイライン表示アニメーションの強化」の対応。

## 変更内容

### UIManager
- `ShowWinAndHighlightAsync` を追加
  - WinPopup 表示と `HighlightWinLinesAsync` を連動して並行実行
  - ポップアップが閉じると同時に `StopWinAnimations` でパルスアニメーションを停止
  - `CancellationTokenSource.CreateLinkedTokenSource` でライフタイムを統一

### GameManager
- 通常スピン・フリースピン両方の Win 表示を `ShowWinAndHighlightAsync` に変更
- 従来の `UniTask.WhenAll(ShowWinAmount, HighlightWinLinesAsync)` を置き換え

## 既存実装（変更なし）

以下は Issue #19 提案内容として既に実装済み：
- `SymbolView.PlayPulseAnimation()` / `PlayIdleAnimation()` — 勝利シンボルのパルスアニメーション
- `PaylineView.AnimateDrawAsync()` — 左→右フロー演出
- `PaylineView.StartGlowAnimation()` — ペイライン光のグロー
- `UIManager.HighlightWinLinesAsync` — 複数ライン順番点灯 → 全点灯
- `SymbolView.SetHighlighted` — 非当選シンボルの暗転

## 動作

1. 勝利時、WinPopup とペイラインハイライトが同時に開始
2. 各ラインを順番にフロー演出で点灯 → 全点灯
3. 勝利シンボルがパルスアニメーション（拡縮繰り返し）
4. **WinPopup が閉じると同時にパルスアニメーションが停止**（今回の追加）

Closes #19