### PR TITLE
キーボードショートカットの拡張実装

### DIFF
--- a/Assets/Editor/SceneBuilder.cs
+++ b/Assets/Editor/SceneBuilder.cs
@@ -307,6 +307,8 @@ namespace SlotGame.Editor
             var audioManagerGO = CreateChild(managerRoot, "AudioManagerGO");
 
             var gameManager  = gameManagerGO.AddComponent<GameManager>();
+            gameManagerGO.AddComponent<PlayerInput>();
+            var inputHandler = gameManagerGO.AddComponent<SlotInputHandler>();
             var spinManager  = spinManagerGO.AddComponent<SpinManager>();
             var bonusManager = bonusManagerGO.AddComponent<BonusManager>();
             var uiManager    = uiManagerGO.AddComponent<UIManager>();
@@ -349,6 +351,12 @@ namespace SlotGame.Editor
             for (int i = 0; i < 5; i++)
                 reels.GetArrayElementAtIndex(i).objectReferenceValue = reelControllers[i];
             so.ApplyModifiedPropertiesWithoutUndo();
+
+            // Input Handler
+            WireField(inputHandler, "gameManager", gameManager);
+            var pinput = gameManagerGO.GetComponent<PlayerInput>();
+            WireField(pinput, "m_Actions", AssetDatabase.LoadAssetAtPath<UnityEngine.InputSystem.InputActionAsset>("Assets/InputSystem_Actions.inputactions"));
+            WireField(pinput, "m_DefaultActionMap", "Slot");
 
             // GameManager
             var gso = new SerializedObject(gameManager);

--- a/Assets/InputSystem_Actions.inputactions
+++ b/Assets/InputSystem_Actions.inputactions
@@ -990,6 +990,185 @@
                     "isPartOfComposite": false
                 }
             ]
+        },
+        {
+            "name": "Slot",
+            "id": "0da48a60-f6ea-4ac9-bc4d-950a3b5828a5",
+            "actions": [
+                {
+                    "name": "Spin",
+                    "type": "Button",
+                    "id": "bd7ea708-5c0d-4921-9e7e-d7b766197454",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "BetUp",
+                    "type": "Button",
+                    "id": "9b822651-44ce-4d8d-acea-bcee430392fd",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "BetDown",
+                    "type": "Button",
+                    "id": "007193bb-3705-4d26-869d-941ead8c1efe",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "AutoSpin",
+                    "type": "Button",
+                    "id": "91f811c3-ad21-4517-986a-ca3ecd2b13bf",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Skip",
+                    "type": "Button",
+                    "id": "4505bc99-6de5-4be5-9bba-2a5bd9a855a6",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Mute",
+                    "type": "Button",
+                    "id": "af192320-899a-464f-8682-df59fa811fba",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Turbo",
+                    "type": "Button",
+                    "id": "9ca1eade-31a0-4038-9db7-da9224fa3b73",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Paytable",
+                    "type": "Button",
+                    "id": "99e5756c-ed9e-4df6-bca4-b3322888c616",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "9209622f-d5ab-4df9-9962-60582b5bf0ca",
+                    "path": "<Keyboard>/space",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Spin",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "89551605-7c78-44dd-9c0d-2c467a563ccb",
+                    "path": "<Keyboard>/enter",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Spin",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "55d489a6-336a-4dc3-8b11-668e50ac673c",
+                    "path": "<Keyboard>/upArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "BetUp",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "9a054933-cf79-4d5b-81ce-e68a233aa824",
+                    "path": "<Keyboard>/downArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "BetDown",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "3a5b6935-e5cc-4b16-a4ad-35e6bea470cd",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "AutoSpin",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "d9144f37-9fff-406e-b14a-582b6098011e",
+                    "path": "<Keyboard>/s",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Skip",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "0fb0af0f-8ff6-453b-a4fa-14783a0d8fff",
+                    "path": "<Keyboard>/m",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Mute",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "1b0b629d-c10d-4d2a-a8bd-e8230e1541b5",
+                    "path": "<Keyboard>/t",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Turbo",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "86fe00ef-fe59-470b-9891-f63c20905220",
+                    "path": "<Keyboard>/p",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Paytable",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
         }
     ],
     "controlSchemes": [

--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -41,6 +41,11 @@ namespace SlotGame.Audio
         [SerializeField] private AudioClip seButtonClick;
 
         private float _lastReelStopPlayTime = -1f;
+        private float _preMuteBgmVolume = 0.8f;
+        private float _preMuteSeVolume = 1.0f;
+        private bool  _isMuted;
+
+        public bool IsMuted => _isMuted;
 
         private void Awake()
         {
@@ -92,12 +97,33 @@ namespace SlotGame.Audio
 
         public void SetBGMVolume(float volume)
         {
-            bgmSource.volume = Mathf.Clamp01(volume);
+            float clamped = Mathf.Clamp01(volume);
+            _preMuteBgmVolume = clamped;
+            if (!_isMuted) bgmSource.volume = clamped;
         }
 
         public void SetSEVolume(float volume)
         {
-            seSource.volume = Mathf.Clamp01(volume);
+            float clamped = Mathf.Clamp01(volume);
+            _preMuteSeVolume = clamped;
+            if (!_isMuted) seSource.volume = clamped;
+        }
+
+        public void ToggleMute()
+        {
+            _isMuted = !_isMuted;
+            if (_isMuted)
+            {
+                _preMuteBgmVolume = bgmSource.volume;
+                _preMuteSeVolume = seSource.volume;
+                bgmSource.volume = 0;
+                seSource.volume = 0;
+            }
+            else
+            {
+                bgmSource.volume = _preMuteBgmVolume;
+                seSource.volume = _preMuteSeVolume;
+            }
         }
 
         /// <summary>BGM をフェードアウトして停止する。</summary>

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -45,6 +45,7 @@ namespace SlotGame.Core
         private int                    _autoSpinCount = 10;
         private bool                   _isInitialized;
         private SlotConfig             _config;
+        private bool                   _isPaytableOpen;
 
         // ─── ライフサイクル ──────────────────────────────────────────────
 
@@ -167,7 +168,7 @@ namespace SlotGame.Core
             uiManager.SeVolumeChanged += HandleSeVolumeChanged;
             uiManager.ResetCoinsRequested += HandleResetCoinsRequested;
             uiManager.SettingsCloseRequested += uiManager.HideSettings;
-            uiManager.PaytableCloseRequested += uiManager.HidePaytable;
+            uiManager.PaytableCloseRequested += () => { uiManager.HidePaytable(); _isPaytableOpen = false; };
             uiManager.StatsCloseRequested    += uiManager.HideStats;
             uiManager.GameDescriptionCloseRequested += uiManager.HideGameDescription;
             uiManager.AutoSpinRequested      += OnAutoSpinButtonPressed;
@@ -288,12 +289,68 @@ namespace SlotGame.Core
 
         public void OnPaytableButtonPressed()
         {
+            _isPaytableOpen = true;
             uiManager.ShowPaytable();
         }
 
         public void OnStatsButtonPressed()
         {
             uiManager.ShowStats();
+        }
+
+        public void ToggleMute()
+        {
+            audioManager.ToggleMute();
+            // Mute状態のときはスライダーを0に見せかけるか、AudioManager側で制御。
+            // ここではセーブデータの更新のみ行う
+            SaveGame();
+        }
+
+        public void IncreaseBet()
+        {
+            if (_currentPhase != GamePhase.Idle) return;
+            int currentIndex = Array.IndexOf(_config.ValidBetAmounts, _gameState.BetAmount);
+            if (currentIndex >= 0 && currentIndex < _config.ValidBetAmounts.Length - 1)
+            {
+                OnBetChanged(_config.ValidBetAmounts[currentIndex + 1]);
+            }
+        }
+
+        public void DecreaseBet()
+        {
+            if (_currentPhase != GamePhase.Idle) return;
+            int currentIndex = Array.IndexOf(_config.ValidBetAmounts, _gameState.BetAmount);
+            if (currentIndex > 0)
+            {
+                OnBetChanged(_config.ValidBetAmounts[currentIndex - 1]);
+            }
+        }
+
+        public void ToggleAutoSpin()
+        {
+            if (_isAutoSpinning)
+            {
+                OnAutoSpinStopRequested();
+            }
+            else
+            {
+                if (_currentPhase != GamePhase.Idle) return;
+                OnAutoSpinButtonPressed(_autoSpinCount);
+            }
+        }
+
+        public void ToggleTurbo()
+        {
+            bool newState = !_gameState.IsTurbo;
+            OnTurboToggled(newState);
+            uiManager.SetTurbo(newState);
+        }
+
+        public void TogglePaytable()
+        {
+            _isPaytableOpen = !_isPaytableOpen;
+            if (_isPaytableOpen) uiManager.ShowPaytable();
+            else uiManager.HidePaytable();
         }
 
         // ─── スピンフロー ────────────────────────────────────────────────

--- a/Assets/Scripts/Core/SlotInputHandler.cs
+++ b/Assets/Scripts/Core/SlotInputHandler.cs
@@ -1,0 +1,81 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace SlotGame.Core
+{
+    /// <summary>
+    /// InputSystem のアクションを GameManager のアクションにバインドするクラス。
+    /// </summary>
+    [RequireComponent(typeof(PlayerInput))]
+    public class SlotInputHandler : MonoBehaviour
+    {
+        [SerializeField] private GameManager gameManager;
+
+        private PlayerInput _playerInput;
+        private InputAction _spinAction;
+        private InputAction _betUpAction;
+        private InputAction _betDownAction;
+        private InputAction _autoSpinAction;
+        private InputAction _skipAction;
+        private InputAction _muteAction;
+        private InputAction _turboAction;
+        private InputAction _paytableAction;
+
+        private void Awake()
+        {
+            if (gameManager == null)
+                gameManager = GetComponent<GameManager>();
+
+            _playerInput = GetComponent<PlayerInput>();
+
+            var actionMap = _playerInput.actions.FindActionMap("Slot");
+            if (actionMap == null)
+            {
+                Debug.LogWarning("[SlotInputHandler] 'Slot' action map not found.");
+                return;
+            }
+
+            _spinAction = actionMap.FindAction("Spin");
+            _betUpAction = actionMap.FindAction("BetUp");
+            _betDownAction = actionMap.FindAction("BetDown");
+            _autoSpinAction = actionMap.FindAction("AutoSpin");
+            _skipAction = actionMap.FindAction("Skip");
+            _muteAction = actionMap.FindAction("Mute");
+            _turboAction = actionMap.FindAction("Turbo");
+            _paytableAction = actionMap.FindAction("Paytable");
+        }
+
+        private void OnEnable()
+        {
+            if (_spinAction != null) _spinAction.performed += OnSpin;
+            if (_betUpAction != null) _betUpAction.performed += OnBetUp;
+            if (_betDownAction != null) _betDownAction.performed += OnBetDown;
+            if (_autoSpinAction != null) _autoSpinAction.performed += OnAutoSpin;
+            if (_skipAction != null) _skipAction.performed += OnSkip;
+            if (_muteAction != null) _muteAction.performed += OnMute;
+            if (_turboAction != null) _turboAction.performed += OnTurbo;
+            if (_paytableAction != null) _paytableAction.performed += OnPaytable;
+        }
+
+        private void OnDisable()
+        {
+            if (_spinAction != null) _spinAction.performed -= OnSpin;
+            if (_betUpAction != null) _betUpAction.performed -= OnBetUp;
+            if (_betDownAction != null) _betDownAction.performed -= OnBetDown;
+            if (_autoSpinAction != null) _autoSpinAction.performed -= OnAutoSpin;
+            if (_skipAction != null) _skipAction.performed -= OnSkip;
+            if (_muteAction != null) _muteAction.performed -= OnMute;
+            if (_turboAction != null) _turboAction.performed -= OnTurbo;
+            if (_paytableAction != null) _paytableAction.performed -= OnPaytable;
+        }
+
+        private void OnSpin(InputAction.CallbackContext context) => gameManager.OnSpinButtonPressed();
+        private void OnBetUp(InputAction.CallbackContext context) => gameManager.IncreaseBet();
+        private void OnBetDown(InputAction.CallbackContext context) => gameManager.DecreaseBet();
+        private void OnAutoSpin(InputAction.CallbackContext context) => gameManager.ToggleAutoSpin();
+        private void OnSkip(InputAction.CallbackContext context) => gameManager.OnSpinButtonPressed(); // SpinButton can handle skip
+        private void OnMute(InputAction.CallbackContext context) => gameManager.ToggleMute();
+        private void OnTurbo(InputAction.CallbackContext context) => gameManager.ToggleTurbo();
+        private void OnPaytable(InputAction.CallbackContext context) => gameManager.TogglePaytable();
+    }
+}


### PR DESCRIPTION
GitHub Issue #17 の「キーボードショートカットの拡張」を実装しました。

### 変更内容
1.  **Input Action Asset の更新**:
    - `Assets/InputSystem_Actions.inputactions` に `Slot` アクションマップを追加。
    - アクション定義: `Spin` (Space/Enter), `BetUp` (↑), `BetDown` (↓), `AutoSpin` (A), `Skip` (S), `Mute` (M), `Turbo` (T), `Paytable` (P)。
2.  **SlotInputHandler.cs の新規作成**:
    - Input System からの入力を受け取り、`GameManager` の対応するメソッドを呼び出すブリッジコンポーネントを実装。
3.  **AudioManager.cs の拡張**:
    - ミュート機能 (`ToggleMute`) を追加。ミュート解除時に直前の音量を復元するように調整。
4.  **GameManager.cs の拡張**:
    - キーボードショートカットから呼び出されるロジック（ベット増減、オートスピン切り替え、ターボ切り替え、ペイテーブル表示切り替え）を実装。
5.  **SceneBuilder.cs の更新**:
    - メインシーン構築時に `PlayerInput` と `SlotInputHandler` を自動的にセットアップするように拡張。

これにより、マウスを使わずにキーボードのみでゲームの全主要操作が可能になりました。

---
*PR created automatically by Jules for task [11155296875279411443](https://jules.google.com/task/11155296875279411443) started by @handism*