### PR TITLE
feat: #17 キーボードショートカットのコンテキスト無効化実装

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -241,13 +241,24 @@ namespace SlotGame.Core
 
         public void OnSpinButtonPressed()
         {
+            if (uiManager.IsModalOpen) return;
+            
             if (_currentPhase == GamePhase.Spinning)
             {
                 spinManager.RequestSkip();
                 return;
             }
-            if (_currentPhase != GamePhase.Idle) return;
+            if (_currentPhase != GamePhase.Idle || _isAutoSpinning) return;
             RunSpinAsync(this.GetCancellationTokenOnDestroy()).Forget();
+        }
+
+        public void RequestSkip()
+        {
+            if (uiManager.IsModalOpen) return;
+            if (_currentPhase == GamePhase.Spinning)
+            {
+                spinManager.RequestSkip();
+            }
         }
 
         public void OnAutoSpinButtonPressed(int count)
@@ -300,6 +311,7 @@ namespace SlotGame.Core
 
         public void ToggleMute()
         {
+            if (uiManager.IsModalOpen) return;
             audioManager.ToggleMute();
             // Mute状態のときはスライダーを0に見せかけるか、AudioManager側で制御。
             // ここではセーブデータの更新のみ行う
@@ -308,6 +320,7 @@ namespace SlotGame.Core
 
         public void IncreaseBet()
         {
+            if (uiManager.IsModalOpen || _isAutoSpinning) return;
             if (_currentPhase != GamePhase.Idle) return;
             int currentIndex = Array.IndexOf(_config.ValidBetAmounts, _gameState.BetAmount);
             if (currentIndex >= 0 && currentIndex < _config.ValidBetAmounts.Length - 1)
@@ -318,6 +331,7 @@ namespace SlotGame.Core
 
         public void DecreaseBet()
         {
+            if (uiManager.IsModalOpen || _isAutoSpinning) return;
             if (_currentPhase != GamePhase.Idle) return;
             int currentIndex = Array.IndexOf(_config.ValidBetAmounts, _gameState.BetAmount);
             if (currentIndex > 0)
@@ -328,6 +342,7 @@ namespace SlotGame.Core
 
         public void ToggleAutoSpin()
         {
+            if (uiManager.IsModalOpen) return;
             if (_isAutoSpinning)
             {
                 OnAutoSpinStopRequested();
@@ -341,6 +356,7 @@ namespace SlotGame.Core
 
         public void ToggleTurbo()
         {
+            if (uiManager.IsModalOpen) return;
             bool newState = !_gameState.IsTurbo;
             OnTurboToggled(newState);
             uiManager.SetTurbo(newState);
@@ -348,6 +364,7 @@ namespace SlotGame.Core
 
         public void TogglePaytable()
         {
+            if (uiManager.IsModalOpen && !_isPaytableOpen) return;
             _isPaytableOpen = !_isPaytableOpen;
             if (_isPaytableOpen) uiManager.ShowPaytable();
             else uiManager.HidePaytable();

--- a/Assets/Scripts/Core/SlotInputHandler.cs
+++ b/Assets/Scripts/Core/SlotInputHandler.cs
@@ -73,7 +73,7 @@ namespace SlotGame.Core
         private void OnBetUp(InputAction.CallbackContext context) => gameManager.IncreaseBet();
         private void OnBetDown(InputAction.CallbackContext context) => gameManager.DecreaseBet();
         private void OnAutoSpin(InputAction.CallbackContext context) => gameManager.ToggleAutoSpin();
-        private void OnSkip(InputAction.CallbackContext context) => gameManager.OnSpinButtonPressed(); // SpinButton can handle skip
+        private void OnSkip(InputAction.CallbackContext context) => gameManager.RequestSkip();
         private void OnMute(InputAction.CallbackContext context) => gameManager.ToggleMute();
         private void OnTurbo(InputAction.CallbackContext context) => gameManager.ToggleTurbo();
         private void OnPaytable(InputAction.CallbackContext context) => gameManager.TogglePaytable();

--- a/Assets/Scripts/View/UIManager.cs
+++ b/Assets/Scripts/View/UIManager.cs
@@ -59,6 +59,8 @@ namespace SlotGame.View
         private static readonly Color FreeSpinCameraColor   = new(0.04f, 0.18f, 0.24f, 1f);
         private static readonly Color BonusRoundCameraColor = new(0.19f, 0.09f, 0.03f, 1f);
 
+        public bool IsModalOpen { get; private set; }
+
         public event System.Action<float>? BgmVolumeChanged;
         public event System.Action<float>? SeVolumeChanged;
         public event System.Action? ResetCoinsRequested;
@@ -560,6 +562,8 @@ namespace SlotGame.View
 
         private void SetHudInteractable(bool interactable)
         {
+            IsModalOpen = !interactable;
+            
             if (_hudCanvasGroup == null)
             {
                 var hudCanvas = mainHUD != null ? mainHUD.GetComponentInParent<Canvas>() : null;


### PR DESCRIPTION
## 概要
Closes #17 を解消するための PR です。
Input Systemによるショートカット（Space/Enterキー、矢印キーなど）の定義自体は `.inputactions` に存在し、`SlotInputHandler` と連結されていましたが、モーダル表示中やオートスピン中などの「無効化すべきコンテキスト」が適切に考慮されていない状態でした。本PRでこの問題を修正し、Issueの要件を満たす実装を追加しています。

## 変更内容
- `UIManager` に `IsModalOpen` プロパティを追加し、設定やペイテーブル等のモーダルが開いている状態を一元管理できるようにしました。
- `GameManager` の各ショートカットメソッド（`OnSpinButtonPressed`、`IncreaseBet`、`ToggleTurbo` など）に `IsModalOpen` および `_isAutoSpinning` のガード処理を追加し、意図しないコンテキストでの入力をブロックしました。
- 「リール即停止 / スキップ」専用のアクション（Sキーなど）が、スピン開始アクションと競合しないよう `GameManager` に `RequestSkip` メソッドを新設しました。これによりIdle時にSキーを押しても余計なスピンが開始されなくなりました。

## 確認方法
- ゲーム待機中にSpace/Enterキーでスピンが開始できること。
- リール回転中にSキーを押下するとリール停止（スキップ処理）が行われること。かつ、Idle時にSキーを押下してもスピンが開始しないこと。
- オートスピン開始後、Idle（次スピン開始直前）のタイミングでもベット額増減（上/下矢印キー）が無視されること。
- 設定画面、ペイテーブル等のモーダル表示中は、いかなるゲームショートカットキーも動作しないこと。
