### PR TITLE
feat: implement staged win presentation based on multiplier (#9)

### DIFF
--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -10,7 +10,7 @@ namespace SlotGame.Audio
     public enum BGMType  { Normal, FreeSpin, BonusRound }
     public enum SEType
     {
-        SpinStart, ReelStop, SmallWin, BigWin, MegaWin,
+        SpinStart, ReelStop, SmallWin, BigWin, MegaWin, EpicWin,
         ScatterAppear, FreeSpinStart, BonusStart,
         ChestSelect, ChestOpen, ButtonClick
     }
@@ -33,6 +33,7 @@ namespace SlotGame.Audio
         [SerializeField] private AudioClip seSmallWin;
         [SerializeField] private AudioClip seBigWin;
         [SerializeField] private AudioClip seMegaWin;
+        [SerializeField] private AudioClip seEpicWin;
         [SerializeField] private AudioClip seScatterAppear;
         [SerializeField] private AudioClip seFreeSpinStart;
         [SerializeField] private AudioClip seBonusStart;
@@ -83,6 +84,7 @@ namespace SlotGame.Audio
                 SEType.SmallWin       => seSmallWin,
                 SEType.BigWin         => seBigWin,
                 SEType.MegaWin        => seMegaWin,
+                SEType.EpicWin        => seEpicWin,
                 SEType.ScatterAppear  => seScatterAppear,
                 SEType.FreeSpinStart  => seFreeSpinStart,
                 SEType.BonusStart     => seBonusStart,
@@ -160,6 +162,7 @@ namespace SlotGame.Audio
             if (seSmallWin == null) missing.Add(nameof(seSmallWin));
             if (seBigWin == null) missing.Add(nameof(seBigWin));
             if (seMegaWin == null) missing.Add(nameof(seMegaWin));
+            if (seEpicWin == null) missing.Add(nameof(seEpicWin));
             if (seScatterAppear == null) missing.Add(nameof(seScatterAppear));
             if (seFreeSpinStart == null) missing.Add(nameof(seFreeSpinStart));
             if (seBonusStart == null) missing.Add(nameof(seBonusStart));
@@ -194,6 +197,7 @@ namespace SlotGame.Audio
             yield return seSmallWin;
             yield return seBigWin;
             yield return seMegaWin;
+            yield return seEpicWin;
             yield return seScatterAppear;
             yield return seFreeSpinStart;
             yield return seBonusStart;

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -479,8 +479,8 @@ namespace SlotGame.Core
                 if (result.TotalWinAmount > 0)
                 {
                     uiManager.UpdateWin(result.TotalWinAmount);
-                    var winLevel = CalcWinLevel(result.TotalWinAmount);
-                    PlayWinSe(result.TotalWinAmount);
+                    var winLevel = CalcWinLevel(result.TotalWinAmount, _gameState.BetAmount);
+                    PlayWinSe(result.TotalWinAmount, _gameState.BetAmount);
 
                     // BigWin以上はBGMをフェードアウトしてファンファーレSEを際立たせる
                     if (winLevel >= WinLevel.Big)
@@ -594,7 +594,7 @@ namespace SlotGame.Core
                     uiManager.ShowFreeSpinHUD(_gameState.FreeSpinsLeft, cumulativeFreeSpinWin);
                     if (result.TotalWinAmount > 0)
                     {
-                        await uiManager.ShowWinAndHighlightAsync(win, CalcWinLevel(win), result, ct, paylineData);
+                        await uiManager.ShowWinAndHighlightAsync(win, CalcWinLevel(win, _gameState.BetAmount), result, ct, paylineData);
                         await UniTask.Delay(TimeSpan.FromSeconds(0.5f), cancellationToken: ct);
                         uiManager.ClearLineHighlights();
                     }
@@ -729,17 +729,21 @@ namespace SlotGame.Core
             return result;
         }
 
-        private static WinLevel CalcWinLevel(long amount)
+        private static WinLevel CalcWinLevel(long amount, int betAmount)
         {
-            if (amount >= 5000) return WinLevel.Mega;
-            if (amount >= 1000) return WinLevel.Big;
+            if (betAmount <= 0) return WinLevel.Small;
+            float multiplier = (float)amount / betAmount;
+            if (multiplier >= 50) return WinLevel.Epic;
+            if (multiplier >= 30) return WinLevel.Mega;
+            if (multiplier >= 15) return WinLevel.Big;
             return WinLevel.Small;
         }
 
-        private void PlayWinSe(long amount)
+        private void PlayWinSe(long amount, int betAmount)
         {
-            var seType = CalcWinLevel(amount) switch
+            var seType = CalcWinLevel(amount, betAmount) switch
             {
+                WinLevel.Epic => SEType.EpicWin,
                 WinLevel.Mega => SEType.MegaWin,
                 WinLevel.Big => SEType.BigWin,
                 _ => SEType.SmallWin

--- a/Assets/Scripts/View/WinLevel.cs
+++ b/Assets/Scripts/View/WinLevel.cs
@@ -1,4 +1,4 @@
 namespace SlotGame.View
 {
-    public enum WinLevel { Small, Big, Mega }
+    public enum WinLevel { Small, Big, Mega, Epic }
 }

--- a/Assets/Scripts/View/WinPopupView.cs
+++ b/Assets/Scripts/View/WinPopupView.cs
@@ -74,7 +74,12 @@ namespace SlotGame.View
             _ = _currentSequence.Append(transform.DOScale(1.0f, 0.15f).SetEase(Ease.OutSine));
 
             // 2. カウントアップ演出（金額を徐々に増やす）
-            float countDuration = (level == WinLevel.Mega) ? 1.5f : (level == WinLevel.Big) ? 1.0f : 0.5f;
+            float countDuration = level switch {
+                WinLevel.Epic => 2.5f,
+                WinLevel.Mega => 1.5f,
+                WinLevel.Big => 1.0f,
+                _ => 0.5f
+            };
             _ = _currentSequence.Join(DOTween.To(() => _countValue, x => {
                 _countValue = x;
                 winAmountText.text = _countValue.ToString("N0");
@@ -87,17 +92,27 @@ namespace SlotGame.View
                 _ = _currentSequence.OnComplete(() => {
                     _ = transform.DOScale(1.15f, 0.4f).SetLoops(-1, LoopType.Yoyo).SetEase(Ease.InOutSine);
                     
-                    if (level == WinLevel.Mega)
+                    if (level >= WinLevel.Mega)
                     {
-                        // MEGA は回転シェイクとズーム
+                        // MEGA/EPIC は回転シェイクとズーム
                         _ = transform.DOShakeRotation(1f, 8f, 15, 90f, false).SetLoops(-1);
                         _ = winAmountText.transform.DOScale(1.2f, 0.3f).SetLoops(-1, LoopType.Yoyo);
+                    }
+                    
+                    if (level == WinLevel.Epic)
+                    {
+                        // EPIC はさらにスケールシェイクを加える
+                        _ = transform.DOShakeScale(1f, 0.15f, 10, 90f, false).SetLoops(-1);
                     }
                 });
             }
 
-            // 指定された時間表示（MEGA の場合は少し長めに）
-            float finalDuration = (level == WinLevel.Mega) ? displayDuration + 1.0f : displayDuration;
+            // 指定された時間表示（MEGA/EPIC の場合は長めに）
+            float finalDuration = level switch {
+                WinLevel.Epic => displayDuration + 2.0f,
+                WinLevel.Mega => displayDuration + 1.0f,
+                _ => displayDuration
+            };
             await UniTask.Delay(TimeSpan.FromSeconds(finalDuration), cancellationToken: ct);
 
             // 4. フェードアウト
@@ -117,6 +132,12 @@ namespace SlotGame.View
 
             switch (level)
             {
+                case WinLevel.Epic:
+                    levelString = "EPIC WIN!";
+                    // EPIC はマゼンタ〜ネオンシアンの鮮烈なグラデーション
+                    top    = new Color(1f, 0f, 0.8f);    // マゼンタ
+                    bottom = new Color(0f, 1f, 1f);      // ネオンシアン
+                    break;
                 case WinLevel.Mega:
                     levelString = "MEGA WIN!";
                     // MEGA は情熱的なレッド〜ゴールドのグラデーション


### PR DESCRIPTION
Resolves #9

## 概要
獲得量とベット額の倍率に応じてウィン演出の段階化を実装しました。

## 変更内容
-  の  を獲得倍率基準へ変更
  - 15倍未満: WIN
  - 15倍以上: BIG WIN
  - 30倍以上: MEGA WIN
  - 50倍以上: EPIC WIN
-  列挙型に  を追加
-  にて  用の専用演出（マゼンタ〜シアンのグラデーション、より激しいシェイク演出など）を追加
-  に  を追加。⚠️ Unityエディタ上で  クラスの  にアセットをアサインする必要があります。
