### PR TITLE
feat: Add interactive tutorial on first launch (Closes #16)

### DIFF
--- a/Assets/Scripts/Core/BootManager.cs
+++ b/Assets/Scripts/Core/BootManager.cs
@@ -36,7 +36,8 @@ namespace SlotGame.Core
                 config?.MaxCoins ?? 9_999_999,
                 config?.ValidBetAmounts ?? new[] { 10, 20, 50, 100 },
                 save.coins,
-                save.betAmount
+                save.betAmount,
+                save.hasCompletedTutorial
             );
             gameState.RestoreStats(save.totalSpins, save.maxWin);
 

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -72,7 +72,8 @@ namespace SlotGame.Core
                     config.MaxCoins,
                     config.ValidBetAmounts,
                     save.coins,
-                    save.betAmount
+                    save.betAmount,
+                    save.hasCompletedTutorial
                 );
                 _gameState.RestoreStats(save.totalSpins, save.maxWin);
 
@@ -109,7 +110,8 @@ namespace SlotGame.Core
                 config.MaxCoins,
                 config.ValidBetAmounts,
                 save.coins,
-                save.betAmount
+                save.betAmount,
+                save.hasCompletedTutorial
             );
             random ??= new SystemRandomGenerator();
 
@@ -176,6 +178,11 @@ namespace SlotGame.Core
             uiManager.TurboToggled           += OnTurboToggled;
             spinManager.ReelStopped += HandleReelStopped;
             TransitionTo(GamePhase.Idle);
+
+            if (!_gameState.HasCompletedTutorial)
+            {
+                RunTutorialSequenceAsync(this.GetCancellationTokenOnDestroy()).Forget();
+            }
         }
 
         private SlotConfig ResolveSlotConfig()
@@ -351,6 +358,30 @@ namespace SlotGame.Core
             _isPaytableOpen = !_isPaytableOpen;
             if (_isPaytableOpen) uiManager.ShowPaytable();
             else uiManager.HidePaytable();
+        }
+
+        private async UniTaskVoid RunTutorialSequenceAsync(CancellationToken ct)
+        {
+            uiManager.SetSpinButtonInteractable(false);
+            uiManager.SetAutoSpinCountInteractable(false);
+
+            try
+            {
+                await uiManager.ShowTutorialAsync(ct);
+            }
+            catch (OperationCanceledException)
+            {
+                // Ignored
+            }
+
+            _gameState.CompleteTutorial();
+            SaveGame();
+
+            if (_currentPhase == GamePhase.Idle)
+            {
+                uiManager.SetSpinButtonInteractable(true);
+                if (!_isAutoSpinning) uiManager.SetAutoSpinCountInteractable(true);
+            }
         }
 
         // ─── スピンフロー ────────────────────────────────────────────────
@@ -658,6 +689,7 @@ namespace SlotGame.Core
                 seVolume   = _seVolume,
                 totalSpins = _gameState.TotalSpins,
                 maxWin     = _gameState.MaxWin,
+                hasCompletedTutorial = _gameState.HasCompletedTutorial
             });
         }
 

--- a/Assets/Scripts/Model/GameState.cs
+++ b/Assets/Scripts/Model/GameState.cs
@@ -12,6 +12,7 @@ namespace SlotGame.Model
         public long Coins { get; private set; }
         public int BetAmount { get; private set; }
         public int FreeSpinsLeft { get; private set; }
+        public bool HasCompletedTutorial { get; private set; }
         public bool IsFreeSpin => FreeSpinsLeft > 0;
         public bool IsTurbo { get; private set; }
         public long TotalSpins { get; private set; }
@@ -29,7 +30,8 @@ namespace SlotGame.Model
             long maxCoins,
             int[] validBetAmounts,
             long currentCoins,
-            int currentBetAmount
+            int currentBetAmount,
+            bool hasCompletedTutorial = false
         )
         {
             InitialCoins = initialCoins;
@@ -37,6 +39,7 @@ namespace SlotGame.Model
             ValidBetAmounts = validBetAmounts;
             Coins = Math.Clamp(currentCoins, 0, MaxCoins);
             BetAmount = currentBetAmount;
+            HasCompletedTutorial = hasCompletedTutorial;
             _sessionStartCoins = Coins;
         }
 
@@ -137,6 +140,12 @@ namespace SlotGame.Model
         {
             TotalSpins = totalSpins;
             MaxWin = maxWin;
+        }
+
+        /// <summary>チュートリアルを完了状態にする。</summary>
+        public void CompleteTutorial()
+        {
+            HasCompletedTutorial = true;
         }
     }
 }

--- a/Assets/Scripts/Model/SaveData.cs
+++ b/Assets/Scripts/Model/SaveData.cs
@@ -13,5 +13,6 @@ namespace SlotGame.Model
         public long   maxWin      = 0;
         public string saveVersion = "1.0";
         public string checksum    = "";
+        public bool   hasCompletedTutorial = false;
     }
 }

--- a/Assets/Scripts/View/TutorialView.cs
+++ b/Assets/Scripts/View/TutorialView.cs
@@ -1,0 +1,179 @@
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace SlotGame.View
+{
+    public class TutorialView : MonoBehaviour
+    {
+        private readonly string[] _steps = {
+            "【1. ベットの変更】\n画面下部の＋/－ボタンで、1スピンあたりの賭けコイン（ベット額）を変更できます。",
+            "【2. スピン】\n右下の「SPIN」ボタンを押すとリールが回転します。長押しや「AUTO」ボタンで自動スピンも可能です。",
+            "【3. 設定 / ペイテーブル】\n画面右下の「i」ボタンや右上の歯車ボタンから、ルールの確認や音量設定が可能です。",
+            "【4. 特殊シンボル】\n「SCATTER(魔法陣)」が3つでフリースピン、「BONUS(宝箱)」が3つ出るとボーナスラウンドに突入します。",
+            "【5. さらに楽しく】\nフリースピン中は配当が2倍！宝箱を選んで大量コイン獲得を目指しましょう！"
+        };
+        private int _currentStep;
+        private TMP_Text _messageText;
+        private Button _nextButton;
+        private Button _skipButton;
+        private CanvasGroup _canvasGroup;
+
+        public event System.Action OnComplete;
+
+        public void Setup()
+        {
+            var rect = gameObject.AddComponent<RectTransform>();
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+
+            var bg = gameObject.AddComponent<Image>();
+            bg.color = new Color(0, 0, 0, 0.8f);
+
+            _canvasGroup = gameObject.AddComponent<CanvasGroup>();
+
+            // パネル作成
+            var panel = new GameObject("Panel", typeof(RectTransform), typeof(Image));
+            panel.transform.SetParent(transform, false);
+            var panelRect = panel.GetComponent<RectTransform>();
+            panelRect.sizeDelta = new Vector2(800, 450);
+            panel.GetComponent<Image>().color = new Color(0.12f, 0.12f, 0.18f, 1f);
+
+            // テキスト作成
+            var textObj = new GameObject("Text", typeof(RectTransform), typeof(TextMeshProUGUI));
+            textObj.transform.SetParent(panel.transform, false);
+            _messageText = textObj.GetComponent<TextMeshProUGUI>();
+            _messageText.rectTransform.anchorMin = new Vector2(0.05f, 0.25f);
+            _messageText.rectTransform.anchorMax = new Vector2(0.95f, 0.9f);
+            _messageText.rectTransform.offsetMin = Vector2.zero;
+            _messageText.rectTransform.offsetMax = Vector2.zero;
+            _messageText.font = TMP_Settings.defaultFontAsset;
+            _messageText.fontSize = 32;
+            _messageText.alignment = TextAlignmentOptions.Center;
+            _messageText.enableWordWrapping = true;
+            _messageText.color = Color.white;
+
+            // 次へボタン
+            var nextObj = new GameObject("NextButton", typeof(RectTransform), typeof(Image), typeof(Button));
+            nextObj.transform.SetParent(panel.transform, false);
+            var nextRect = nextObj.GetComponent<RectTransform>();
+            nextRect.anchorMin = new Vector2(0.55f, 0.05f);
+            nextRect.anchorMax = new Vector2(0.9f, 0.2f);
+            nextRect.offsetMin = Vector2.zero;
+            nextRect.offsetMax = Vector2.zero;
+            nextObj.GetComponent<Image>().color = new Color(0.1f, 0.4f, 0.6f);
+            _nextButton = nextObj.GetComponent<Button>();
+            _nextButton.onClick.AddListener(OnNextClicked);
+
+            var nextTextObj = new GameObject("Text", typeof(RectTransform), typeof(TextMeshProUGUI));
+            nextTextObj.transform.SetParent(nextObj.transform, false);
+            var nextText = nextTextObj.GetComponent<TextMeshProUGUI>();
+            SetStampRect(nextText.rectTransform);
+            nextText.font = TMP_Settings.defaultFontAsset;
+            nextText.text = "次へ";
+            nextText.color = Color.white;
+            nextText.alignment = TextAlignmentOptions.Center;
+            nextText.fontSize = 28;
+
+            // スキップボタン
+            var skipObj = new GameObject("SkipButton", typeof(RectTransform), typeof(Image), typeof(Button));
+            skipObj.transform.SetParent(panel.transform, false);
+            var skipRect = skipObj.GetComponent<RectTransform>();
+            skipRect.anchorMin = new Vector2(0.1f, 0.05f);
+            skipRect.anchorMax = new Vector2(0.45f, 0.2f);
+            skipRect.offsetMin = Vector2.zero;
+            skipRect.offsetMax = Vector2.zero;
+            skipObj.GetComponent<Image>().color = new Color(0.4f, 0.4f, 0.4f);
+            _skipButton = skipObj.GetComponent<Button>();
+            _skipButton.onClick.AddListener(OnSkipClicked);
+
+            var skipTextObj = new GameObject("Text", typeof(RectTransform), typeof(TextMeshProUGUI));
+            skipTextObj.transform.SetParent(skipObj.transform, false);
+            var skipText = skipTextObj.GetComponent<TextMeshProUGUI>();
+            SetStampRect(skipText.rectTransform);
+            skipText.font = TMP_Settings.defaultFontAsset;
+            skipText.text = "スキップ";
+            skipText.color = Color.white;
+            skipText.alignment = TextAlignmentOptions.Center;
+            skipText.fontSize = 28;
+            
+            UpdateStep();
+            gameObject.SetActive(false);
+        }
+
+        private void SetStampRect(RectTransform rect)
+        {
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+        }
+
+        private void OnNextClicked()
+        {
+            _currentStep++;
+            if (_currentStep >= _steps.Length)
+            {
+                Finish();
+            }
+            else
+            {
+                UpdateStep();
+            }
+        }
+
+        private void OnSkipClicked()
+        {
+            Finish();
+        }
+
+        private void UpdateStep()
+        {
+            _messageText.text = _steps[_currentStep];
+            if (_currentStep == _steps.Length - 1)
+            {
+                _nextButton.GetComponentInChildren<TextMeshProUGUI>().text = "閉じる";
+            }
+            else
+            {
+                _nextButton.GetComponentInChildren<TextMeshProUGUI>().text = "次へ";
+            }
+        }
+
+        private void Finish()
+        {
+            gameObject.SetActive(false);
+            OnComplete?.Invoke();
+        }
+
+        public async UniTask ShowAsync(CancellationToken ct)
+        {
+            _currentStep = 0;
+            UpdateStep();
+            gameObject.SetActive(true);
+            
+            var tcs = new UniTaskCompletionSource();
+            
+            System.Action completeAction = null;
+            completeAction = () => 
+            {
+                OnComplete -= completeAction;
+                tcs.TrySetResult();
+            };
+            OnComplete += completeAction;
+
+            using (ct.Register(() => 
+            {
+                OnComplete -= completeAction;
+                tcs.TrySetCanceled();
+            }))
+            {
+                await tcs.Task;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/View/UIManager.cs
+++ b/Assets/Scripts/View/UIManager.cs
@@ -50,6 +50,7 @@ namespace SlotGame.View
         private Camera? _mainCamera;
         private CanvasGroup? _hudCanvasGroup;
         private DotPatternBackground? _dotPatternBg;
+        private TutorialView? _tutorialView;
 
         private static readonly Color NormalTint     = new(0.05f, 0.08f, 0.14f, 0f);
         private static readonly Color FreeSpinTint   = new(0.08f, 0.36f, 0.52f, 0.3f);
@@ -508,6 +509,32 @@ namespace SlotGame.View
         {
             _lastDescriptionText = text;
             if (gameDescriptionView != null) gameDescriptionView.SetDescription(text);
+        }
+
+        public async UniTask ShowTutorialAsync(CancellationToken ct)
+        {
+            if (_tutorialView == null)
+            {
+                _rootCanvas ??= mainHUD != null ? mainHUD.GetComponentInParent<Canvas>() : FindFirstObjectByType<Canvas>();
+                if (_rootCanvas == null) return;
+
+                var go = new GameObject("TutorialView", typeof(RectTransform));
+                go.transform.SetParent(_rootCanvas.transform, false);
+                go.transform.SetAsLastSibling();
+
+                _tutorialView = go.AddComponent<TutorialView>();
+                _tutorialView.Setup();
+            }
+
+            SetHudInteractable(false);
+            try
+            {
+                await _tutorialView.ShowAsync(ct);
+            }
+            finally
+            {
+                SetHudInteractable(true);
+            }
         }
 
         public void UpdateStats(in SlotGame.Model.SessionStats stats) => statsView?.UpdateDisplay(stats);


### PR DESCRIPTION
Closes #16. 

## 概要
初回起動時に各種操作（ベット、スピン、ペイテーブル等）をテキストとUIで案内するインタラクティブなチュートリアルを追加しました。

## 変更内容
- **Model**: `SaveData` と `GameState` に `hasCompletedTutorial` 状態を追加
- **View**: `TutorialView` クラスを新規追加し、uGUIベースで案内パネルと「次へ」「スキップ」ボタンを動的に表示する処理を実装
- **Core**: `GameManager` 起動時に `hasCompletedTutorial` が `false` ならば `UIManager.ShowTutorialAsync` を呼び出し一連の案内を行うように修正