### PR TITLE
feat: ターボスピン機能の完全実装 (Issue #15)

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -124,6 +124,7 @@ namespace SlotGame.Core
             _bgmVolume = save.bgmVolume;
             _seVolume  = save.seVolume;
             _autoSpinCount = config.DefaultAutoSpinCount;
+            _gameState.SetTurbo(save.isTurbo);
 
             // セーブデータが完全に新規（一度も保存されていない）場合のみ、Config のデフォルト値を優先する。
             // チェックサムがない、または totalSpins が 0 かつ default 値と一致する場合は新規とみなす。
@@ -151,6 +152,7 @@ namespace SlotGame.Core
             uiManager.UpdateBet(_gameState.BetAmount);
             uiManager.UpdateWin(0);
             uiManager.SetAutoButtonText(GetAutoSpinButtonText());
+            uiManager.SetTurbo(_gameState.IsTurbo);
             uiManager.SetSettingsVolumes(_bgmVolume, _seVolume);
             uiManager.PopulatePaytable(CollectSymbolDefinitions(), payoutData);
             uiManager.SetGameDescriptionText(
@@ -207,8 +209,10 @@ namespace SlotGame.Core
                 0.8f,
                 1.0f,
                 "SALTY_SLOT_2026",
-                0.8f,
-                0.1f);
+                0.5f,
+                0.1f,
+                2.0f,
+                0.3f);
         }
 
         private void OnApplicationPause(bool pauseStatus)
@@ -537,7 +541,8 @@ namespace SlotGame.Core
                     await uiManager.HighlightWinLinesAsync(result, ct, paylineData);
                 }
 
-                await UniTask.Delay(TimeSpan.FromSeconds(0.5f), cancellationToken: ct);
+                float postWinDelay = _gameState.IsTurbo ? 0.1f : 0.5f;
+                await UniTask.Delay(TimeSpan.FromSeconds(postWinDelay), cancellationToken: ct);
                 uiManager.ClearLineHighlights();
             }
             else
@@ -706,7 +711,8 @@ namespace SlotGame.Core
                 seVolume   = _seVolume,
                 totalSpins = _gameState.TotalSpins,
                 maxWin     = _gameState.MaxWin,
-                hasCompletedTutorial = _gameState.HasCompletedTutorial
+                hasCompletedTutorial = _gameState.HasCompletedTutorial,
+                isTurbo    = _gameState.IsTurbo
             });
         }
 

--- a/Assets/Scripts/Core/SpinManager.cs
+++ b/Assets/Scripts/Core/SpinManager.cs
@@ -56,8 +56,8 @@ namespace SlotGame.Core
             var gameState = GameContext.GameState;
             var config = GameContext.SaveDataManager.Config;
 
-            float spinDuration = gameState.IsTurbo ? config.TurboSpinDuration : 2.0f;
-            float stopInterval = gameState.IsTurbo ? config.TurboStopInterval : 0.3f;
+            float spinDuration = gameState.IsTurbo ? config.TurboSpinDuration : config.NormalSpinDuration;
+            float stopInterval = gameState.IsTurbo ? config.TurboStopInterval : config.NormalStopInterval;
 
             // 停止位置をリールごとに乱数決定
             var stopIndices = new int[reels.Length];

--- a/Assets/Scripts/Data/GameConfigData.cs
+++ b/Assets/Scripts/Data/GameConfigData.cs
@@ -23,6 +23,10 @@ namespace SlotGame.Data
         [Header("Auto Spin")]
         public int defaultAutoSpinCount = 10;
 
+        [Header("Normal Mode")]
+        public float normalSpinDuration = 2.0f;
+        public float normalStopInterval = 0.3f;
+
         [Header("Turbo Mode")]
         public float turboSpinDuration = 0.5f;
         public float turboStopInterval = 0.1f;
@@ -52,7 +56,9 @@ namespace SlotGame.Data
                 defaultSeVolume,
                 checksumSalt,
                 turboSpinDuration,
-                turboStopInterval
+                turboStopInterval,
+                normalSpinDuration,
+                normalStopInterval
             );
         }
     }

--- a/Assets/Scripts/Model/SaveData.cs
+++ b/Assets/Scripts/Model/SaveData.cs
@@ -14,5 +14,6 @@ namespace SlotGame.Model
         public string saveVersion = "1.0";
         public string checksum    = "";
         public bool   hasCompletedTutorial = false;
+        public bool   isTurbo = false;
     }
 }

--- a/Assets/Scripts/Model/SlotConfig.cs
+++ b/Assets/Scripts/Model/SlotConfig.cs
@@ -19,6 +19,8 @@ namespace SlotGame.Model
         float DefaultSeVolume,
         string ChecksumSalt,
         float TurboSpinDuration,
-        float TurboStopInterval
+        float TurboStopInterval,
+        float NormalSpinDuration,
+        float NormalStopInterval
     );
 }


### PR DESCRIPTION
## 概要

Issue #15 のターボスピン機能を完全に実装します。設定の永続化・起動時 UI 同期・マジックナンバーの排除を行います。

## 変更内容

### Model / Data
- **SlotConfig.cs** — `NormalSpinDuration` / `NormalStopInterval` を record に追加
- **GameConfigData.cs** — `normalSpinDuration (2.0f)` / `normalStopInterval (0.3f)` フィールドを追加し、`ToModelConfig` で `SlotConfig` に渡すよう修正
- **SaveData.cs** — `isTurbo` フィールドを追加

### Core
- **SpinManager.cs** — ハードコードされていた `2.0f` / `0.3f` を `config.NormalSpinDuration` / `config.NormalStopInterval` に置換
- **GameManager.cs**
  - `Initialize`: `_gameState.SetTurbo(save.isTurbo)` でセーブデータからターボ状態を復元
  - `Start`: `uiManager.SetTurbo(_gameState.IsTurbo)` で起動時 UI を同期
  - `SpinOnceAsync`: 配当演出後の待機をターボ時 0.1s / 通常時 0.5s に分岐
  - `SaveGame`: `isTurbo` を保存対象に追加
  - `ResolveSlotConfig`: フォールバック値を修正（TurboSpin=0.5f、Normal=2.0f/0.3f）

## 確認項目

- [ ] ターボボタンをクリックし、リール停止速度が速くなることを確認
- [ ] アプリ再起動時にターボ状態が維持されていることを確認
- [ ] T キーでターボがトグルすることを確認

Closes #15