### PR TITLE
Issue #82: 統計情報をセーブデータに永続化する

### DIFF
--- a/Assets/Scripts/Core/BootManager.cs
+++ b/Assets/Scripts/Core/BootManager.cs
@@ -39,7 +39,7 @@ namespace SlotGame.Core
                 save.betAmount,
                 save.hasCompletedTutorial
             );
-            gameState.RestoreStats(save.totalSpins, save.maxWin);
+            gameState.RestoreStats(save.totalSpins, save.totalWins, save.maxWin, save.totalFreeSpinTriggers);
 
             var random = new SystemRandomGenerator();
 

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -76,7 +76,7 @@ namespace SlotGame.Core
                     save.betAmount,
                     save.hasCompletedTutorial
                 );
-                _gameState.RestoreStats(save.totalSpins, save.maxWin);
+                _gameState.RestoreStats(save.totalSpins, save.totalWins, save.maxWin, save.totalFreeSpinTriggers);
 
                 var random = new SystemRandomGenerator();
                 Initialize(_gameState, _saveDataManager, random, save);
@@ -556,7 +556,7 @@ namespace SlotGame.Core
             }
 
             SaveGame();
-            uiManager.UpdateStats(_gameState.GetSessionStats());
+            uiManager.UpdateStats(_gameState.GetLifetimeStats());
 
             // ボーナス・フリースピン判定
             if (result.HasBonusCondition)
@@ -595,7 +595,7 @@ namespace SlotGame.Core
             uiManager.UpdateCoins(_gameState.Coins);
             uiManager.UpdateWin(win);
             SaveGame();
-            uiManager.UpdateStats(_gameState.GetSessionStats());
+            uiManager.UpdateStats(_gameState.GetLifetimeStats());
 
             await audioManager.CrossFadeBGM(BGMType.Normal, 0.5f, ct);
             uiManager.ApplyModeVisual(ModeVisualType.Normal);
@@ -643,7 +643,7 @@ namespace SlotGame.Core
 
             uiManager.HideFreeSpinHUD();
             SaveGame();
-            uiManager.UpdateStats(_gameState.GetSessionStats());
+            uiManager.UpdateStats(_gameState.GetLifetimeStats());
 
             await audioManager.CrossFadeBGM(BGMType.Normal, 0.5f, ct);
             uiManager.ApplyModeVisual(ModeVisualType.Normal);
@@ -714,7 +714,9 @@ namespace SlotGame.Core
                 bgmVolume  = _bgmVolume,
                 seVolume   = _seVolume,
                 totalSpins = _gameState.TotalSpins,
+                totalWins  = _gameState.TotalWins,
                 maxWin     = _gameState.MaxWin,
+                totalFreeSpinTriggers = _gameState.TotalFreeSpinTriggers,
                 hasCompletedTutorial = _gameState.HasCompletedTutorial,
                 isTurbo    = _gameState.IsTurbo
             });

--- a/Assets/Scripts/Model/GameState.cs
+++ b/Assets/Scripts/Model/GameState.cs
@@ -16,7 +16,9 @@ namespace SlotGame.Model
         public bool IsFreeSpin => FreeSpinsLeft > 0;
         public bool IsTurbo { get; private set; }
         public long TotalSpins { get; private set; }
+        public long TotalWins { get; private set; }
         public long MaxWin { get; private set; }
+        public int  TotalFreeSpinTriggers { get; private set; }
 
         // ─── セッション統計（インメモリのみ・永続化なし） ───────────────────
         private long _sessionStartCoins;
@@ -107,15 +109,17 @@ namespace SlotGame.Model
             _sessionTotalSpins++;
             if (winAmount > 0)
             {
+                TotalWins++;
                 _sessionWins++;
                 if (winAmount > _sessionLargestWin)
                     _sessionLargestWin = winAmount;
             }
         }
 
-        /// <summary>フリースピンが発動した回数をセッション統計に記録する。</summary>
+        /// <summary>フリースピンが発動した回数をライフタイム統計・セッション統計に記録する。</summary>
         public void RecordFreeSpinTrigger()
         {
+            TotalFreeSpinTriggers++;
             _sessionFreeSpinTriggers++;
         }
 
@@ -135,11 +139,29 @@ namespace SlotGame.Model
                 Coins - _sessionStartCoins);
         }
 
-        /// <summary>統計・フリースピンを含む全状態をセーブデータから復元する。</summary>
-        public void RestoreStats(long totalSpins, long maxWin)
+        /// <summary>統計をセーブデータから復元する。</summary>
+        public void RestoreStats(long totalSpins, long totalWins, long maxWin, int totalFreeSpinTriggers)
         {
             TotalSpins = totalSpins;
-            MaxWin = maxWin;
+            TotalWins  = totalWins;
+            MaxWin     = maxWin;
+            TotalFreeSpinTriggers = totalFreeSpinTriggers;
+        }
+
+        /// <summary>ライフタイム統計のスナップショットを返す（統計パネル表示用）。</summary>
+        public SessionStats GetLifetimeStats()
+        {
+            float winRate = TotalSpins > 0
+                ? (float)TotalWins / TotalSpins * 100f
+                : 0f;
+
+            return new SessionStats(
+                TotalSpins,
+                TotalWins,
+                winRate,
+                MaxWin,
+                TotalFreeSpinTriggers,
+                Coins - _sessionStartCoins);
         }
 
         /// <summary>チュートリアルを完了状態にする。</summary>

--- a/Assets/Scripts/Model/SaveData.cs
+++ b/Assets/Scripts/Model/SaveData.cs
@@ -10,7 +10,9 @@ namespace SlotGame.Model
         public float  bgmVolume   = 0.8f;
         public float  seVolume    = 1.0f;
         public long   totalSpins  = 0;
+        public long   totalWins   = 0;
         public long   maxWin      = 0;
+        public int    totalFreeSpinTriggers = 0;
         public string saveVersion = "1.0";
         public string checksum    = "";
         public bool   hasCompletedTutorial = false;

--- a/Assets/Scripts/Utility/SaveDataManager.cs
+++ b/Assets/Scripts/Utility/SaveDataManager.cs
@@ -99,14 +99,15 @@ namespace SlotGame.Utility
             }
             if (data.bgmVolume < 0f || data.bgmVolume > 1f) return false;
             if (data.seVolume  < 0f || data.seVolume  > 1f) return false;
-            if (data.totalSpins < 0 || data.maxWin < 0)     return false;
+            if (data.totalSpins < 0 || data.totalWins < 0 || data.maxWin < 0) return false;
+            if (data.totalFreeSpinTriggers < 0)              return false;
             return true;
         }
 
         private static string CalculateChecksum(SaveData data, SlotConfig? config)
         {
             string salt = config != null ? config.ChecksumSalt : "SALTY_SLOT_2026";
-            string raw = $"{data.coins}:{data.betAmount}:{data.bgmVolume:F2}:{data.seVolume:F2}:{data.totalSpins}:{data.maxWin}:{data.saveVersion}:{salt}";
+            string raw = $"{data.coins}:{data.betAmount}:{data.bgmVolume:F2}:{data.seVolume:F2}:{data.totalSpins}:{data.totalWins}:{data.maxWin}:{data.totalFreeSpinTriggers}:{data.saveVersion}:{salt}";
             using var sha256 = System.Security.Cryptography.SHA256.Create();
             byte[] bytes = sha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(raw));
             return Convert.ToBase64String(bytes);

--- a/Assets/Tests/EditMode/GameStateTests.cs
+++ b/Assets/Tests/EditMode/GameStateTests.cs
@@ -138,5 +138,57 @@ namespace SlotGame.Tests.EditMode
             state.SetTurbo(false);
             Assert.IsFalse(state.IsTurbo);
         }
+
+        [Test]
+        public void RecordSpin_WinAmount_IncrementsTotalWins()
+        {
+            var state = CreateState();
+            state.RecordSpin(0);
+            Assert.AreEqual(0, state.TotalWins);
+            state.RecordSpin(100);
+            Assert.AreEqual(1, state.TotalWins);
+            state.RecordSpin(0);
+            Assert.AreEqual(1, state.TotalWins);
+            state.RecordSpin(50);
+            Assert.AreEqual(2, state.TotalWins);
+        }
+
+        [Test]
+        public void RecordFreeSpinTrigger_IncrementsTotalFreeSpinTriggers()
+        {
+            var state = CreateState();
+            Assert.AreEqual(0, state.TotalFreeSpinTriggers);
+            state.RecordFreeSpinTrigger();
+            state.RecordFreeSpinTrigger();
+            Assert.AreEqual(2, state.TotalFreeSpinTriggers);
+        }
+
+        [Test]
+        public void RestoreStats_SetsAllLifetimeFields()
+        {
+            var state = CreateState();
+            state.RestoreStats(totalSpins: 100, totalWins: 40, maxWin: 500, totalFreeSpinTriggers: 3);
+            Assert.AreEqual(100, state.TotalSpins);
+            Assert.AreEqual(40,  state.TotalWins);
+            Assert.AreEqual(500, state.MaxWin);
+            Assert.AreEqual(3,   state.TotalFreeSpinTriggers);
+        }
+
+        [Test]
+        public void GetLifetimeStats_ReturnsLifetimeValues()
+        {
+            var state = CreateState(coins: 1000);
+            state.RestoreStats(totalSpins: 10, totalWins: 4, maxWin: 200, totalFreeSpinTriggers: 2);
+            state.AddCoins(500);
+
+            var stats = state.GetLifetimeStats();
+
+            Assert.AreEqual(10,    stats.TotalSpins);
+            Assert.AreEqual(4,     stats.Wins);
+            Assert.AreEqual(40f,   stats.WinRate, 0.01f);
+            Assert.AreEqual(200,   stats.LargestWin);
+            Assert.AreEqual(2,     stats.FreeSpinTriggers);
+            Assert.AreEqual(500,   stats.NetProfit); // セッション損益
+        }
     }
 }


### PR DESCRIPTION
## 概要

- `SaveData` に `totalWins`・`totalFreeSpinTriggers` フィールドを追加
- `GameState` にライフタイム統計プロパティ（`TotalWins`・`TotalFreeSpinTriggers`）を追加
- `RecordSpin()` / `RecordFreeSpinTrigger()` でライフタイム統計も更新するよう修正
- `RestoreStats()` のシグネチャを拡張し、起動時に全統計を復元
- 統計パネルの表示をセッション統計からライフタイム統計に変更（`GetLifetimeStats()`）
- `SaveDataManager` のチェックサム・バリデーションに新フィールドを追加

## 対応 Issue

Closes #82

## 変更ファイル

- `Assets/Scripts/Model/SaveData.cs`
- `Assets/Scripts/Model/GameState.cs`
- `Assets/Scripts/Utility/SaveDataManager.cs`
- `Assets/Scripts/Core/BootManager.cs`
- `Assets/Scripts/Core/GameManager.cs`
- `Assets/Tests/EditMode/GameStateTests.cs`

## テスト・検証

- [x] Edit Mode ユニットテスト追加（4件）
- [ ] Unity Play Mode でスピン後に統計パネルが正しい値を表示するか手動確認
- [ ] ゲーム再起動後に統計が維持されるか手動確認
- [ ] 既存セーブデータの読み込みが正常にフォールバックするか手動確認

## 備考

- `NetProfit` はセッション起点の概念のため、引き続きセッション値を表示
- 既存セーブデータとの互換性：チェックサムなしの旧データは既存の移行戦略で対処済み

🤖 Generated with [Claude Code](https://claude.ai/claude-code)