### PR TITLE
docs: ADR-004 の SymbolData 数を 10 → 12 に修正

### DIFF
--- a/docs/adr/ADR-004-scriptableobject-config.md
+++ b/docs/adr/ADR-004-scriptableobject-config.md
@@ -24,7 +24,7 @@
 **ScriptableObject を採用する。**
 
 対象アセット:
-- `SymbolData` × 10（各シンボルの配当・スプライト・アニメ）
+- `SymbolData` × 12（各シンボルの配当・スプライト・アニメ）
 - `ReelStripData` × 5（各リールの出目テーブル）
 - `PaylineData` × 1（25ラインの定義）
 - `PayoutTableData` × 1（Scatter 配当、ボーナス報酬重み）


### PR DESCRIPTION
## 概要

- `docs/adr/ADR-004-scriptableobject-config.md` の `SymbolData × 10` を `SymbolData × 12` に修正

## 対応 Issue

Closes #91

## 変更ファイル

- `docs/adr/ADR-004-scriptableobject-config.md`

## テスト・検証

- [x] ドキュメント修正のみのため、手動テスト不要

🤖 Generated with [Claude Code](https://claude.ai/claude-code)