### PR TITLE
docs: design.md の MainHUDView betSlider をベットボタン方式に修正

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -438,7 +438,8 @@ public class MainHUDView : MonoBehaviour
     [SerializeField] TMP_Text  betText;
     [SerializeField] Button    spinButton;
     [SerializeField] Button    autoSpinButton;
-    [SerializeField] Slider    betSlider;
+    // ベット選択ボタン（10 / 20 / 50 / 100 コインの 4 段階）
+    [SerializeField] Button[]  betButtons;
 
     // オートスピン回数の選択肢（デフォルト: 10 / 25 / 50 / 100）
     // Inspector または直接編集で変更可能。変更時は Unity Editor 上で


### PR DESCRIPTION
## 概要

- `docs/design.md` の `MainHUDView` 定義から誤った `Slider betSlider` を削除
- 実装・要件定義書と一致するベットボタン方式（`Button[] betButtons`）の記述に修正

## 対応 Issue

Closes #89

## 変更ファイル

- `docs/design.md`（`MainHUDView` クラス定義の修正）

## テスト・検証

- [x] `requirements.md` の仕様（10/20/50/100 ベットボタン方式）と一致することを確認
- [x] `Assets/Scripts/View/MainHUDView.cs` の実装（`Button[] betButtons`）と一致することを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)