### PR TITLE
fix: フリースピン勝利額計算のオーバーフローを防止しMaxCoinsでクランプ

### DIFF
--- a/Assets/Scripts/Core/BonusManager.cs
+++ b/Assets/Scripts/Core/BonusManager.cs
@@ -54,7 +54,7 @@ namespace SlotGame.Core
 
                 // フリースピン中は配当を指定倍率（デフォルト×2）で計算
                 int multiplier = payouts != null ? payouts.freeSpinMultiplier : 2;
-                long freeSpinWin = result.TotalWinAmount * multiplier;
+                long freeSpinWin = Math.Min((long)multiplier * result.TotalWinAmount, state.MaxCoins);
                 state.AddCoins(freeSpinWin);
                 state.RecordSpin(freeSpinWin);
 

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -628,7 +628,7 @@ namespace SlotGame.Core
                 async result =>
                 {
                     int multiplier = payoutData != null ? payoutData.freeSpinMultiplier : 2;
-                    long win = result.TotalWinAmount * multiplier;
+                    long win = Math.Min((long)multiplier * result.TotalWinAmount, _gameState.MaxCoins);
                     cumulativeFreeSpinWin += win;
                     uiManager.UpdateCoins(_gameState.Coins);
                     uiManager.UpdateWin(win);


### PR DESCRIPTION
## 概要

- `BonusManager.cs` / `GameManager.cs` のフリースピン勝利額計算で `(long)multiplier * result.TotalWinAmount` に変更し、`Math.Min(..., MaxCoins)` で上限クランプを追加

## 対応 Issue

Closes #101

## 変更ファイル

- `Assets/Scripts/Core/BonusManager.cs` L57
- `Assets/Scripts/Core/GameManager.cs` L631

## テスト・検証

- [ ] Unity Play Mode でフリースピンを発生させ、勝利額が MaxCoins を超えないことを確認
- [ ] 極端に大きな TotalWinAmount を渡す単体テストでオーバーフローが起きないことを確認

## 備考

`int multiplier` を先に `(long)` キャストすることで乗算前のオーバーフローを排除。`Math.Min` で `MaxCoins` 上限に収めることで保存データ破損時にも安全。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)