### PR TITLE
Fix: Kill lingering DOTween tweens on cancellation (Closes #100)

### DIFF
--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -132,8 +132,16 @@ namespace SlotGame.Audio
         public async UniTask FadeOutBGM(float duration, CancellationToken ct)
         {
             float startVolume = bgmSource.volume;
-            await DOTween.To(() => bgmSource.volume, v => bgmSource.volume = v, 0f, duration)
-                         .ToUniTask(cancellationToken: ct);
+            Tween tween = null;
+            try
+            {
+                tween = DOTween.To(() => bgmSource.volume, v => bgmSource.volume = v, 0f, duration);
+                await tween.ToUniTask(cancellationToken: ct);
+            }
+            finally
+            {
+                tween?.Kill();
+            }
             bgmSource.Stop();
             bgmSource.volume = startVolume;
         }
@@ -144,8 +152,16 @@ namespace SlotGame.Audio
             await FadeOutBGM(duration * 0.5f, ct);
             PlayBGM(type);
             bgmSource.volume = 0f;
-            await DOTween.To(() => bgmSource.volume, v => bgmSource.volume = v, _preMuteBgmVolume, duration * 0.5f)
-                         .ToUniTask(cancellationToken: ct);
+            Tween tween = null;
+            try
+            {
+                tween = DOTween.To(() => bgmSource.volume, v => bgmSource.volume = v, _preMuteBgmVolume, duration * 0.5f);
+                await tween.ToUniTask(cancellationToken: ct);
+            }
+            finally
+            {
+                tween?.Kill();
+            }
         }
 
         private void ValidateConfiguration()

--- a/Assets/Scripts/View/ReelView.cs
+++ b/Assets/Scripts/View/ReelView.cs
@@ -96,29 +96,47 @@ namespace SlotGame.View
 
             // バウンスアニメーション（リール全体）
             float bounceAmount = 30f;
-            await DOTween.To(
-                        () => _scrollOffset,
-                        value =>
-                        {
-                            _scrollOffset = value;
-                            UpdateSymbolPositions();
-                        },
-                        -bounceAmount,
-                        0.1f)
-                    .SetEase(Ease.OutQuad)
-                    .ToUniTask(cancellationToken: ct);
+            Tween tween = null;
+            try
+            {
+                tween = DOTween.To(
+                            () => _scrollOffset,
+                            value =>
+                            {
+                                _scrollOffset = value;
+                                UpdateSymbolPositions();
+                            },
+                            -bounceAmount,
+                            0.1f)
+                        .SetEase(Ease.OutQuad);
 
-            await DOTween.To(
-                        () => _scrollOffset,
-                        value =>
-                        {
-                            _scrollOffset = value;
-                            UpdateSymbolPositions();
-                        },
-                        0f,
-                        0.15f)
-                    .SetEase(Ease.OutBounce)
-                    .ToUniTask(cancellationToken: ct);
+                await tween.ToUniTask(cancellationToken: ct);
+            }
+            finally
+            {
+                tween?.Kill();
+            }
+
+            tween = null;
+            try
+            {
+                tween = DOTween.To(
+                            () => _scrollOffset,
+                            value =>
+                            {
+                                _scrollOffset = value;
+                                UpdateSymbolPositions();
+                            },
+                            0f,
+                            0.15f)
+                        .SetEase(Ease.OutBounce);
+
+                await tween.ToUniTask(cancellationToken: ct);
+            }
+            finally
+            {
+                tween?.Kill();
+            }
 
             // 全シンボルを整列
             SnapAllToGrid();


### PR DESCRIPTION
## 概要

- キャンセル発生時に DOTween の `Tween` が内部リストに残留する可能性がある問題を修正しました。
- 各 `DOTween.To` の戻り値を `Tween` に保持し、`try/finally` で `tween?.Kill()` を行う実装に変更しています。

## 対応 Issue

Closes #100

## 変更ファイル

- Assets/Scripts/View/ReelView.cs
- Assets/Scripts/Audio/AudioManager.cs

## テスト・検証

- [ ] Play Mode でスピン中にキャンセルを発生させ、Tween の残留や例外が発生しないことを確認
- [ ] Edit Mode テストがある場合は実行（該当なし）

## 備考

- `Tween.Kill()` は既に完了/破棄済みの Tween に対しても安全に呼べるはずですが、念のため Play Mode での動作確認をお願いします。